### PR TITLE
Cleanup script - tentative fix

### DIFF
--- a/arch/stowme.sh
+++ b/arch/stowme.sh
@@ -8,5 +8,4 @@ sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfi
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-ssh
 cd $HOME || return
 dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh starship
-git reset --hard HEAD
 exit 0

--- a/steamos/stowme.sh
+++ b/steamos/stowme.sh
@@ -4,5 +4,4 @@ sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfi
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-ssh
 cd $HOME || return
 dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh starship
-git reset --hard HEAD
 exit 0


### PR DESCRIPTION
Basically resets the local repository when stowing. It happens on Arch-based distros, and some Debian ones.
For some reason, Termux just working fine, but will do on a separate branch.

Fixes/relates the following issues:
- #77