### PR TITLE
Support for Supermodel - Sega Model 3 arcade emulator

### DIFF
--- a/arch/stowme.sh
+++ b/arch/stowme.sh
@@ -7,5 +7,5 @@
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-cleanup
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-ssh
 cd $HOME || return
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh starship
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh supermodel starship
 exit 0

--- a/debian/stowme.sh
+++ b/debian/stowme.sh
@@ -2,5 +2,5 @@
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-cleanup
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-ssh
 cd $HOME || return
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh starship
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh supermodel starship
 exit 0

--- a/linux/supermodel/.supermodel/Config/Supermodel.ini
+++ b/linux/supermodel/.supermodel/Config/Supermodel.ini
@@ -1,0 +1,476 @@
+;;
+;; Supermodel Configuration File
+;; Default settings.
+;;
+
+
+;
+; Quick Overview
+; --------------
+;
+; All settings are case sensitive.  Numbers must be integers.  Check your
+; spelling carefully because invalid settings are silently ignored.  To verify
+; that your settings are being parsed correctly, check the contents of
+; Supermodel.log.
+;
+; Global options apply to all games.  To create configuration profiles for
+; individual games, place settings under sections with the same name as the
+; corresponding MAME ROM set, like so:
+;
+;       ; Scud Race
+;       [ scud ]
+;
+;       SoundVolume = 50
+;       MusicVolume = 200
+;       ; ... etc. ...
+;
+; For a list of all valid settings, please consult README.txt.  Only default
+; inputs are assigned here.
+;
+
+[ daytona2 ]
+MusicVolume = 120
+SoundVolume = 100
+Balance = -10
+InputJoy1XSaturation = 155
+
+[ dayto2pe ]
+MusicVolume = 120
+SoundVolume = 100
+Balance = -10
+InputJoy1XSaturation = 165
+
+[ dirtdvls ]
+MusicVolume = 100
+SoundVolume = 130
+Balance = -20
+InputJoy1XSaturation = 118
+
+[ getbassur ]
+WideScreen =0
+WideBackground =0
+MusicVolume = 100
+SoundVolume = 110
+Balance = 10
+
+[ eca ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = -35
+
+[ fvipers2 ]
+LegacySoundDSP = 1
+MusicVolume = 100
+SoundVolume = 170
+Balance = 10
+
+[ harley ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = 10
+
+[ lamachin ]
+MusicVolume = 100
+SoundVolume = 115
+Balance = 0
+WideScreen =0
+WideBackground =0
+
+[ lemans24 ]
+MusicVolume = 100
+SoundVolume = 110
+Balance = 0
+InputJoy1XSaturation = 120
+
+[ lostwsga ]
+MusicVolume = 100
+SoundVolume = 105
+Balance = 20
+WideScreen =0
+WideBackground =0
+
+[ magtruck ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = 15
+WideScreen =0
+WideBackground =0
+
+[ mgtrkbad ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = 15
+
+[ oceanhun ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = 0
+WideScreen =0
+WideBackground =0
+
+[ oceanhuna ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = 0
+WideScreen =0
+WideBackground =0
+
+[ scud ]
+MusicVolume = 200
+SoundVolume = 60
+Balance = 0
+InputJoy1XSaturation = 155
+
+[ scudplus ]
+MusicVolume = 200
+SoundVolume = 60
+Balance = 0
+InputJoy1XSaturation = 155
+
+[ skichamp ]
+MusicVolume = 100
+SoundVolume = 200
+Balance = 10
+ForceFeedback=1
+WideScreen =0
+WideBackground =0
+
+
+[ spikeofe ]
+MusicVolume = 120
+SoundVolume = 120
+Balance = 0
+WideScreen =0
+WideBackground =0
+
+[ spikeout ]
+MusicVolume = 90
+SoundVolume = 90
+Balance = 0
+WideScreen =0
+WideBackground =0
+
+
+[ srally2 ]
+LegacySoundDSP =1
+SoundVolume = 155
+MusicVolume = 140
+Balance = 15
+PowerPCFrequency=70
+InputJoy1XSaturation = 150
+
+[ srally2dx ]
+LegacySoundDSP =1
+SoundVolume = 155
+MusicVolume = 140
+Balance = 15
+PowerPCFrequency=75
+InputJoy1XSaturation = 150
+
+[ swtrilgy ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = 0
+
+
+[ vf3 ]
+MusicVolume = 100
+SoundVolume = 110
+Balance = -5
+WideScreen =0
+WideBackground =0
+
+[ vf3tb ]
+MusicVolume = 100
+SoundVolume = 110
+Balance = -5
+
+[ von2 ]
+MusicVolume = 100
+SoundVolume = 100
+Balance = 0
+
+[ vs2 ]
+MusicVolume = 100
+SoundVolume = 110
+Balance = -10
+WideScreen =0
+WideBackground =0
+
+[ vs298 ]
+MusicVolume = 100
+SoundVolume = 110
+Balance = -10
+WideScreen =0
+WideBackground =0
+
+[ vs2v991 ]
+MusicVolume = 100
+SoundVolume = 110
+Balance = -10
+WideScreen =0
+WideBackground =0
+
+[ Global ]
+
+; Graphics
+New3DEngine = 1
+QuadRendering = 1
+WideScreen = 0
+Stretch = 0
+WideBackground = 0
+FullScreen = 1
+XResolution = 1280
+YResolution = 720
+
+; Refresh rate (milliHertz accuracy). Actual Model 3 refresh rate is 57.524 Hz
+; but this can cause judder so we use 60 Hz by default.
+RefreshRate = 60.000
+
+; Legacy SCSP DSP implementation for games that do not play well with the newer
+; one (e.g., Fighting Vipers 2)
+LegacySoundDSP =0
+
+; Network board
+Network =0
+SimulateNet =0
+PortIn =1970
+PortOut =1971
+AddressOut =127.0.0.1
+
+; Common
+InputStart1 = "KEY_1,JOY1_BUTTON8"
+InputStart2 = "KEY_2,JOY2_BUTTON8"
+InputCoin1 = "KEY_3,JOY1_BUTTON7"
+InputCoin2 = "KEY_4,JOY2_BUTTON7"
+InputServiceA = "KEY_5"
+InputServiceB = "KEY_7"
+InputTestA = "KEY_6"
+InputTestB = "KEY_8"
+
+; 4-way digital joysticks (Fighting Vipers 2, Spikeout, Spikeout Final Edition, Virtua Fighter 3, Virtua Striker 2)
+InputJoyUp = "JOY1_YAXIS_NEG,JOY1_POV1_UP"
+InputJoyDown = "JOY1_YAXIS_POS,JOY1_POV1_DOWN"
+InputJoyLeft = "JOY1_XAXIS_NEG,JOY1_POV1_LEFT"
+InputJoyRight = "JOY1_XAXIS_POS,JOY1_POV1_RIGHT"
+InputJoyUp2 = "JOY2_YAXIS_NEG,JOY2_POV1_UP"
+InputJoyDown2 = "JOY2_YAXIS_POS,JOY2_POV1_DOWN"
+InputJoyLeft2 = "JOY2_XAXIS_NEG,JOY2_POV1_LEFT"
+InputJoyRight2 = "JOY2_XAXIS_POS,JOY2_POV1_RIGHT"
+
+; Fighting game buttons (Fighting Vipers 2, Virtua Fighter 3)
+InputPunch = "JOY1_BUTTON3"
+InputKick = "JOY1_BUTTON4"
+InputGuard = "JOY1_BUTTON1"
+InputEscape = "JOY1_BUTTON2"
+InputPunch2 = "JOY2_BUTTON3"
+InputKick2 = "JOY2_BUTTON4"
+InputGuard2 = "JOY2_BUTTON1"
+InputEscape2 = "JOY2_BUTTON2"
+
+; Spikeout buttons
+InputShift = "JOY1_BUTTON2,JOY1_BUTTON6"
+InputBeat = "JOY1_BUTTON1"
+InputCharge = "JOY1_BUTTON3"
+InputJump = "JOY1_BUTTON4"
+
+; Virtua Striker buttons
+InputShortPass = "JOY1_BUTTON3"
+InputLongPass = "JOY1_BUTTON1"
+InputShoot = "JOY1_BUTTON2"
+InputShortPass2 = "JOY2_BUTTON3"
+InputLongPass2 = "JOY2_BUTTON1"
+InputShoot2 = "JOY2_BUTTON2"
+
+; Steering wheel
+InputSteeringLeft = "NONE"          ; digital, turn wheel left
+InputSteeringRight = "NONE"         ; digital, turn wheel right
+InputSteering = "JOY1_XAXIS"        ; analog, full steering range
+
+; Pedals
+InputAccelerator = "JOY1_RZAXIS_POS"
+InputBrake = "JOY1_ZAXIS_POS"
+
+; Up/down shifter manual transmission (all racers - Dirt Devils, ECA, Harley-Davidson, Le Mans 24 are shift manual only)
+InputGearShiftUp = "JOY1_BUTTON6"           ; sequential shift up
+InputGearShiftDown = "JOY1_BUTTON5"         ; sequential shift down
+
+; 4-Speed manual transmission (Daytona 2, Sega Rally 2, Scud Race)
+InputGearShift1 = "JOY1_BUTTON3"
+InputGearShift2 = "JOY1_BUTTON1"
+InputGearShift3 = "JOY1_BUTTON4"
+InputGearShift4 = "JOY1_BUTTON2"
+InputGearShiftN = "NONE"
+
+; VR4 view change buttons (Daytona 2, Le Mans 24, Scud Race)
+InputVR1 = "JOY1_POV1_UP"
+InputVR2 = "JOY1_POV1_DOWN"
+InputVR3 = "JOY1_POV1_LEFT"
+InputVR4 = "JOY1_POV1_RIGHT"
+
+; Single view change button (Dirt Devils, ECA, Harley-Davidson, Sega Rally 2)
+InputViewChange = "JOY1_POV1_UP"
+
+; Handbrake (Sega Rally 2)
+InputHandBrake = "JOY1_RYAXIS_POS"
+
+; Harley-Davidson controls
+InputRearBrake = "JOY1_BUTTON1"
+InputMusicSelect = "JOY1_BUTTON2"
+
+; Virtual On macros
+InputTwinJoyTurnLeft = "JOY1_RXAXIS_NEG"
+InputTwinJoyTurnRight = "JOY1_RXAXIS_POS"
+InputTwinJoyForward = "JOY1_YAXIS_NEG"
+InputTwinJoyReverse = "JOY1_YAXIS_POS"
+InputTwinJoyStrafeLeft = "JOY1_XAXIS_NEG"
+InputTwinJoyStrafeRight = "JOY1_XAXIS_POS"
+InputTwinJoyJump = "JOY1_BUTTON4"
+InputTwinJoyCrouch = "JOY1_BUTTON1"
+
+; Virtual On individual joystick mapping
+InputTwinJoyLeft1 = "NONE"
+InputTwinJoyLeft2 = "NONE"
+InputTwinJoyRight1 = "NONE"
+InputTwinJoyRight2 = "NONE"
+InputTwinJoyUp1 = "NONE"
+InputTwinJoyUp2 = "NONE"
+InputTwinJoyDown1 = "NONE"
+InputTwinJoyDown2 = "NONE"
+
+; Virtual On buttons
+InputTwinJoyShot1 = "JOY1_ZAXIS_POS"
+InputTwinJoyShot2 = "JOY1_RZAXIS_POS"
+InputTwinJoyTurbo1 = "JOY1_BUTTON3,JOY1_BUTTON5"
+InputTwinJoyTurbo2 = "JOY1_BUTTON2,JOY1_BUTTON6"
+
+; Analog joystick (Star Wars Trilogy)
+InputAnalogJoyLeft = "NONE"             ; digital, move left
+InputAnalogJoyRight = "NONE"            ; digital, move right
+InputAnalogJoyUp = "NONE"               ; digital, move up
+InputAnalogJoyDown = "NONE"             ; digital, move down
+InputAnalogJoyX = "JOY1_XAXIS_INV,MOUSE_XAXIS_INV"   ; analog, full X axis
+InputAnalogJoyY = "JOY1_YAXIS_INV,MOUSE_YAXIS"   ; analog, full Y axis
+InputAnalogJoyTrigger = "JOY1_BUTTON3,MOUSE_LEFT_BUTTON"
+InputAnalogJoyEvent = "JOY1_BUTTON1,JOY1_BUTTON11,MOUSE_RIGHT_BUTTON"
+InputAnalogJoyTrigger2 = "NONE"
+InputAnalogJoyEvent2 = "NONE"
+
+; Light guns (Lost World-only applies when set to 'gun' in Games.xml)
+InputGunLeft = "NONE"                 ; digital, move gun left
+InputGunRight = "NONE"                ; digital, move gun right
+InputGunUp = "NONE"                   ; digital, move gun up
+InputGunDown = "NONE"                 ; digital, move gun down
+InputGunX = "JOY1_XAXIS,MOUSE_XAXIS"    ; analog, full X axis
+InputGunY = "JOY1_YAXIS,MOUSE_YAXIS"    ; analog, full Y axis
+InputTrigger = "JOY1_BUTTON3,MOUSE_LEFT_BUTTON"
+InputOffscreen = "MOUSE_RIGHT_BUTTON,JOY1_BUTTON1,JOY1_BUTTON11"    ; point off-screen
+InputAutoTrigger = 1                    ; automatic reload when off-screen
+InputGunLeft2 = "NONE"
+InputGunRight2 = "NONE"
+InputGunUp2 = "NONE"
+InputGunDown2 = "NONE"
+InputGunX2 = "JOY2_XAXIS,MOUSE2_XAXIS"
+InputGunY2 = "JOY2_YAXIS,MOUSE2_YAXIS"
+InputTrigger2 = "JOY2_BUTTON3,MOUSE2_LEFT_BUTTON"
+InputOffscreen2 = "JOY2_BUTTON1,MOUSE2_RIGHT_BUTTON"
+InputAutoTrigger2 = 1
+
+; Analog guns (Ocean Hunter, LA Machineguns, Lost World-when set to default 'analog_gun' in Games.xml)
+InputAnalogGunLeft = "NONE"               ; digital, move gun left
+InputAnalogGunRight = "NONE"              ; digital, move gun right
+InputAnalogGunUp = "NONE"                 ; digital, move gun up
+InputAnalogGunDown = "NONE"               ; digital, move gun down
+InputAnalogGunX = "JOY1_XAXIS,MOUSE_XAXIS"    ; analog, full X axis
+InputAnalogGunY = "JOY1_YAXIS,MOUSE_YAXIS"    ; analog, full Y axis
+InputAnalogTriggerLeft = "JOY1_BUTTON3,MOUSE_LEFT_BUTTON"    ;Lost World trigger
+InputAnalogTriggerRight = "JOY1_BUTTON1,JOY1_BUTTON11,MOUSE_RIGHT_BUTTON"    ;Lost World off-screen
+InputAnalogGunLeft2 = "NONE"
+InputAnalogGunRight2 = "NONE"
+InputAnalogGunUp2 = "NONE"
+InputAnalogGunDown2 = "NONE"
+InputAnalogGunX2 = "JOY2_XAXIS,MOUSE2_XAXIS"
+InputAnalogGunY2 = "JOY2_YAXIS,MOUSE2_YAXIS"
+InputAnalogTriggerLeft2 = "JOY2_ZAXIS_NEG,JOY2_BUTTON3,MOUSE2_LEFT_BUTTON"    ;Lost World trigger
+InputAnalogTriggerRight2 = "JOY2_BUTTON1,MOUSE2_RIGHT_BUTTON"    ;Lost World off-screen
+
+; Ski Champ controls
+InputSkiLeft = "NONE"
+InputSkiRight = "NONE"
+InputSkiUp = "NONE"
+InputSkiDown = "NONE"
+InputSkiX = "JOY1_XAXIS"
+InputSkiY = "JOY1_RXAXIS"
+InputSkiPollLeft = "JOY1_ZAXIS_POS"
+InputSkiPollRight = "JOY1_RZAXIS_POS"
+InputSkiSelect1 = "JOY1_BUTTON3"
+InputSkiSelect2 = "JOY1_BUTTON1"
+InputSkiSelect3 = "JOY1_BUTTON2"
+
+; Magical Truck Adventure controls
+InputMagicalLeverUp1 = "NONE"
+InputMagicalLeverDown1 = "NONE"
+InputMagicalLeverUp2 = "NONE"
+InputMagicalLeverDown2 = "NONE"
+InputMagicalLever1 = "JOY1_YAXIS"
+InputMagicalLever2 = "JOY2_YAXIS"
+InputMagicalPedal1 = "JOY1_BUTTON1"
+InputMagicalPedal2 = "JOY2_BUTTON1"
+
+; Sega Bass Fishing / Get Bass controls
+InputFishingRodLeft = "NONE"
+InputFishingRodRight = "NONE"
+InputFishingRodUp = "NONE"
+InputFishingRodDown = "NONE"
+InputFishingStickLeft = "NONE"
+InputFishingStickRight = "NONE"
+InputFishingStickUp = "NONE"
+InputFishingStickDown = "NONE"
+InputFishingRodX = "JOY1_XAXIS"
+InputFishingRodY = "JOY1_YAXIS"
+InputFishingStickX = "JOY1_RXAXIS"
+InputFishingStickY = "JOY1_RYAXIS"
+InputFishingReel = "JOY1_RZAXIS_POS"
+InputFishingCast = "JOY1_BUTTON3"
+InputFishingSelect = "JOY1_BUTTON1"
+InputFishingTension = "NONE"
+Crosshairs=1
+PowerPCFrequency=69
+GPUMultiThreaded=1
+MultiThreaded=1
+MultiTexture=0
+EmulateSound=1
+FullScreen=1
+Throttle=0
+ShowFrameRate=1
+FlipStereo=0
+VSync=1
+; XResolution=1280
+; YResolution=800
+EmulateDSB=1
+NbSoundChannels=4
+ForceFeedback=1
+port_in=1970
+port_out=port_out
+addr_out=addr_out
+EmulateNet=0
+InputSystem=sdl
+InputJoy1XDeadZone=7
+InputJoy1YDeadZone=7
+InputJoy2XDeadZone=7
+InputJoy2YDeadZone=7
+MusicVolume=100
+SoundVolume=100
+Balance=0
+XInputConstForceThreshold=20
+XInputConstForceMax=40
+XInputVibrateMax=100
+DirectInputConstForceLeftMax=100
+DirectInputConstForceRightMax=100
+DirectInputSelfCenterMax=100
+DirectInputFrictionMax=100
+DirectInputVibrateMax=100
+[Supermodel3 UI]
+Legacy=0
+HideCMD=0
+Dir=ROMs

--- a/linux/supermodel/.supermodel/Config/Supermodel.ini
+++ b/linux/supermodel/.supermodel/Config/Supermodel.ini
@@ -33,12 +33,16 @@ MusicVolume = 120
 SoundVolume = 100
 Balance = -10
 InputJoy1XSaturation = 155
+WideScreen = 1
+WideBackground = 1
 
 [ dayto2pe ]
 MusicVolume = 120
 SoundVolume = 100
 Balance = -10
 InputJoy1XSaturation = 165
+WideScreen = 1
+WideBackground = 1
 
 [ dirtdvls ]
 MusicVolume = 100
@@ -73,8 +77,11 @@ Balance = 10
 MusicVolume = 100
 SoundVolume = 115
 Balance = 0
-WideScreen =0
-WideBackground =0
+WideScreen = 1
+WideBackground = 1
+MultiThreaded = 1
+MultiTexture = 1
+FullScreen = 1
 
 [ lemans24 ]
 MusicVolume = 100
@@ -120,12 +127,16 @@ MusicVolume = 200
 SoundVolume = 60
 Balance = 0
 InputJoy1XSaturation = 155
+WideScreen = 1
+WideBackground = 1
 
 [ scudplus ]
 MusicVolume = 200
 SoundVolume = 60
 Balance = 0
 InputJoy1XSaturation = 155
+WideScreen = 1
+WideBackground = 1
 
 [ skichamp ]
 MusicVolume = 100

--- a/linux/supermodel/.supermodel/Config/Supermodel.ini
+++ b/linux/supermodel/.supermodel/Config/Supermodel.ini
@@ -3,7 +3,6 @@
 ;; Default settings.
 ;;
 
-
 ;
 ; Quick Overview
 ; --------------
@@ -146,7 +145,6 @@ ForceFeedback=1
 WideScreen =0
 WideBackground =0
 
-
 [ spikeofe ]
 MusicVolume = 120
 SoundVolume = 120
@@ -161,7 +159,6 @@ Balance = 0
 WideScreen =0
 WideBackground =0
 
-
 [ srally2 ]
 LegacySoundDSP =1
 SoundVolume = 155
@@ -169,6 +166,8 @@ MusicVolume = 140
 Balance = 15
 PowerPCFrequency=70
 InputJoy1XSaturation = 150
+WideScreen = 1
+WideBackground = 1
 
 [ srally2dx ]
 LegacySoundDSP =1
@@ -177,6 +176,8 @@ MusicVolume = 140
 Balance = 15
 PowerPCFrequency=75
 InputJoy1XSaturation = 150
+WideScreen = 1
+WideBackground = 1
 
 [ swtrilgy ]
 MusicVolume = 100

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-cleanup
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-cleanup
@@ -80,6 +80,7 @@ rm -f $HOME/.pyenv/version
 rm -f $HOME/.ruby-version
 rm -f $HOME/.gemrc
 rm -f $HOME/.railsrc
+rm -f $HOME/.supermodel/Config/Supermodel.ini
 
 # Avoid removing ssh
 echo 'y' || cp -rf $HOME/.ssh $HOME/.ssh-backup

--- a/rhel/stowme.sh
+++ b/rhel/stowme.sh
@@ -5,6 +5,6 @@ cd $HOME || return
 # Workaround for Fedora
 export LD_PRELOAD="/usr/lib64/libgcrypt.so.20"
 # Generic
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh starship
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh supermodel starship
 export LD_PRELOAD=
 exit 0

--- a/steamos/stowme.sh
+++ b/steamos/stowme.sh
@@ -3,5 +3,5 @@
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-cleanup
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-ssh
 cd $HOME || return
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh starship
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh supermodel starship
 exit 0

--- a/ubuntu/stowme.sh
+++ b/ubuntu/stowme.sh
@@ -2,5 +2,5 @@
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-cleanup
 sh $HOME/.dotfiles/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-ssh
 cd $HOME || return
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh starship
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems flatpak alacritty wireplumber flags lindbergh supermodel starship
 exit 0


### PR DESCRIPTION
Support for Supermodel - Sega Model 3 arcade emulator.
Just frustrated on how EmuDeck handles the configuration for Model 3 emulation.
I don't like using widescreen, and Steam Deck's latest build is becoming messy (being too wide).

More information:
https://emudeck.github.io/emulators/steamos/supermodel/