### PR TITLE
dotfiles-arch

### DIFF
--- a/arch/setup.sh
+++ b/arch/setup.sh
@@ -49,87 +49,15 @@ sudo localectl set-locale LANG=en_US.UTF-8
 # Install essentials
 pacman_install "-Syyu --noconfirm --noprogressbar" nano htop iftop mtr dkms lz4 bash-completion base-devel pacman-contrib git zsh unzip
 pacman_install "-S --noconfirm --noprogressbar" base-devel python3 zip unzip vi nano fakeroot openssh stow sqlite tmux wget entr less
-# Ensure temp directory exists
-mkdir -p temp && cd temp/
-# Install yay
-git clone https://aur.archlinux.org/yay.git $HOME/yay
-cd $HOME/yay
-makepkg -si --noconfirm
-# Install AUR packages
-yay -S --noconfirm podman-docker-git
 
-# Cleanup
-cd ../..
-rm -rf temp/
-
-# Chaotic AUR
-if ! grep -q "\[chaotic-aur\]" /etc/pacman.conf; then
-  echo 'Importing essential keys...'
-  sudo pacman-key --recv-key 3056513887B78AEB --keyserver hkp://keyserver.ubuntu.com:80
-  echo 'Signing keys...'
-  sudo pacman-key --lsign-key 3056513887B78AEB
-  echo 'Begin installing Chaotic AUR...'
-  sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'
-  # Backup the pacman.conf file
-  sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
-  # Add the Chaotic AUR repository to pacman.conf
-  echo "
-[chaotic-aur]
-Include = /etc/pacman.d/chaotic-mirrorlist" | sudo tee -a /etc/pacman.conf
-  # Synchronize and upgrade packages
-  sudo pacman -Syyu --noconfirm --noprogressbar
-else
-  echo "chaotic-aur repository is already registered. Skipping..."
-fi
-
-# CachyOS Repository
-if ! grep -q "\[cachyos-v3\]" /etc/pacman.conf; then
-  echo 'Importing CachyOS keys...'
-  sudo pacman-key --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com
-  echo 'Signing CachyOS keys...'
-  sudo pacman-key --lsign-key F3B607488DB35A47
-  echo 'Installing CachyOS keyring and mirrorlist...'
-  sudo pacman -U --noconfirm \
-    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-keyring-20240331-1-any.pkg.tar.zst' \
-    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-mirrorlist-27-1-any.pkg.tar.zst' \
-    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst' \
-    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v4-mirrorlist-27-1-any.pkg.tar.zst'
-  sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
-  echo "
-[cachyos-v3]
-Include = /etc/pacman.d/cachyos-v3-mirrorlist
-
-[cachyos-core-v3]
-Include = /etc/pacman.d/cachyos-v3-mirrorlist
-
-[cachyos-extra-v3]
-Include = /etc/pacman.d/cachyos-v3-mirrorlist
-
-[cachyos]
-Include = /etc/pacman.d/cachyos-mirrorlist
-" | sudo tee -a /etc/pacman.conf
-  sudo pacman -Syyu --noconfirm --noprogressbar
-else
-  echo "CachyOS repository is already registered. Skipping..."
-fi
-
-# Install CachyOS packages
-pacman_install "-S --noconfirm --noprogressbar" dmemcg-booster kcgroups plasma-foreground-booster
-
-# Installing rclone
-pacman_install "-S --noconfirm --noprogressbar" rclone
+# AUR repository setup, yay installation, and AUR packages are now handled by
+# the dotfiles-arch utility. Run `dotfiles-arch setup` after this script.
 
 # Compilation Cache
 pacman_install "-S --noconfirm --noprogressbar" ccache
 
-# Programming languages
-pacman_install "-S --noconfirm --noprogressbar" chaotic-aur/nvm
-pacman_install "-S --noconfirm --noprogressbar" rbenv pyenv
-pacman_install "-S --noconfirm --noprogressbar" aur/phpenv-git
-
 # Workarounds & Misc software
-pacman_install "-S --noconfirm --noprogressbar" aur/pam_ssh_agent_auth
-pacman_install "-S --noconfirm --noprogressbar" xclip xsel ncdu
+pacman_install "-S --noconfirm --noprogressbar" xclip
 # Install mirror management tools
 pacman_install "-S --noconfirm --noprogressbar" rankmirrors reflector
 

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
@@ -56,3 +56,4 @@ dotfiles-arch install-packages
 - `arch/setup.sh` has been stripped of AUR-related logic; use `dotfiles-arch` for that instead.
 - On SteamOS, any command that modifies the system checks `steamos-readonly status` first. If the rootfs is read-only, the script exits with instructions to run `dotfiles-steamdeck writeable` or `sudo steamos-readonly disable`.
 - `install-yay` installs `debugedit` and `fakeroot` if missing, since SteamOS 3.8.10+ removed them but `makepkg` requires them to build `yay-bin`.
+- Zsh tab completion is available for `dotfiles-arch` via `~/.zsh/completions/_dotfiles-arch` after stowing the `zsh` package.

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
@@ -1,0 +1,56 @@
+# Agent Notes: dotfiles-bin
+
+This directory contains user-local utility scripts for the dotfiles setup.
+
+## `bin/dotfiles-arch`
+
+Arch Linux helper for setting up AUR repositories, repairing the pacman keyring, and installing AUR/edge packages on any Arch-based system.
+
+### Commands
+
+```text
+setup / all              Full chain: fix-keyring → setup-repositories → install-yay → install-packages
+fix-keyring              Initialize or repair the pacman keyring
+setup-repositories       Add Chaotic AUR and CachyOS repositories
+install-yay              Build and install yay-bin from AUR
+install-packages         Install mandatory packages (podman-docker-git, xsel, ncdu, rclone)
+install-packages-edge    Install optional edge packages (dmemcg-booster, kcgroups, plasma-foreground-booster)
+help                     Show usage
+```
+
+### Options
+
+- `-o`, `--optional` — When used with `setup`, also runs `install-packages-edge`.
+- Options may appear before or after the command, e.g. `dotfiles-arch --optional setup` or `dotfiles-arch setup -o`.
+
+### install-packages
+
+- `install-packages` should only include essential or working or stable packages or any that are available on reputable sources.
+- `install-packages-edge` should only include experimental packages that are not suitable to all systems, and this is mostly for power users.
+
+#### Adding AUR package into install-packages
+
+- For any AUR-related requests, you must search online regarding the safety implications, since a specific package from AUR could be orphaned or infected with malwares, backdoors, etc., so make a research and then report back to the user.
+
+### Examples
+
+```sh
+# Full setup without edge packages
+dotfiles-arch setup
+
+# Full setup including edge packages
+dotfiles-arch setup --optional
+
+# Run individual steps
+dotfiles-arch fix-keyring
+dotfiles-arch setup-repositories
+dotfiles-arch install-yay
+dotfiles-arch install-packages
+```
+
+### Notes for agents
+
+- All steps are idempotent: they check whether repositories/packages already exist before acting.
+- This script is **not** invoked by `start.sh`; it is intended to be run manually when AUR setup is needed.
+- SteamOS-specific handling (e.g. `steamos-readonly`, `holo` keyring) is kept in `dotfiles-steamdeck` and `steamos/setup.sh`, not here.
+- `arch/setup.sh` has been stripped of AUR-related logic; use `dotfiles-arch` for that instead.

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
@@ -13,7 +13,7 @@ setup / all              Full chain: fix-keyring → setup-repositories → inst
 fix-keyring              Initialize or repair the pacman keyring
 setup-repositories       Add Chaotic AUR and CachyOS repositories
 install-yay              Build and install yay-bin from AUR
-install-packages         Install mandatory packages (xsel, ncdu, rclone)
+install-packages         Install mandatory packages (podman-docker, xsel, ncdu, rclone)
 install-packages-edge    Install optional edge packages (dmemcg-booster, kcgroups, plasma-foreground-booster)
 help                     Show usage
 ```

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/AGENTS.md
@@ -13,7 +13,7 @@ setup / all              Full chain: fix-keyring → setup-repositories → inst
 fix-keyring              Initialize or repair the pacman keyring
 setup-repositories       Add Chaotic AUR and CachyOS repositories
 install-yay              Build and install yay-bin from AUR
-install-packages         Install mandatory packages (podman-docker-git, xsel, ncdu, rclone)
+install-packages         Install mandatory packages (xsel, ncdu, rclone)
 install-packages-edge    Install optional edge packages (dmemcg-booster, kcgroups, plasma-foreground-booster)
 help                     Show usage
 ```
@@ -54,3 +54,5 @@ dotfiles-arch install-packages
 - This script is **not** invoked by `start.sh`; it is intended to be run manually when AUR setup is needed.
 - SteamOS-specific handling (e.g. `steamos-readonly`, `holo` keyring) is kept in `dotfiles-steamdeck` and `steamos/setup.sh`, not here.
 - `arch/setup.sh` has been stripped of AUR-related logic; use `dotfiles-arch` for that instead.
+- On SteamOS, any command that modifies the system checks `steamos-readonly status` first. If the rootfs is read-only, the script exits with instructions to run `dotfiles-steamdeck writeable` or `sudo steamos-readonly disable`.
+- `install-yay` installs `debugedit` and `fakeroot` if missing, since SteamOS 3.8.10+ removed them but `makepkg` requires them to build `yay-bin`.

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
@@ -1,0 +1,309 @@
+#!/bin/sh
+
+set -eu
+
+# Arch Linux utility for managing AUR repositories, keyring, and AUR packages.
+# Works on all Arch-based systems (including SteamOS when combined with
+# dotfiles-steamdeck for SteamOS-specific handling).
+
+# Space-separated package list to force install on file conflicts.
+# Example: PACMAN_FORCE_CONFLICT_PACKAGES="python3 openssh" dotfiles-arch setup
+PACMAN_FORCE_CONFLICT_PACKAGES="${PACMAN_FORCE_CONFLICT_PACKAGES:-}"
+PACMAN_OVERWRITE_GLOB="${PACMAN_OVERWRITE_GLOB:-*}"
+
+log_info() {
+  echo "[dotfiles-arch] $1"
+}
+
+log_error() {
+  echo "[dotfiles-arch] ERROR: $1" >&2
+}
+
+is_forced_package() {
+  package_name="$1"
+  for forced_pkg in $PACMAN_FORCE_CONFLICT_PACKAGES; do
+    if [ "$forced_pkg" = "$package_name" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+pacman_install() {
+  pacman_args="$1"
+  shift
+
+  regular_packages=""
+  forced_packages=""
+
+  for package_name in "$@"; do
+    if is_forced_package "$package_name"; then
+      forced_packages="$forced_packages $package_name"
+    else
+      regular_packages="$regular_packages $package_name"
+    fi
+  done
+
+  if [ -n "$regular_packages" ]; then
+    sudo pacman $pacman_args $regular_packages || return 1
+  fi
+
+  if [ -n "$forced_packages" ]; then
+    log_info "Installing forced packages with overwrite glob: $PACMAN_OVERWRITE_GLOB"
+    sudo pacman $pacman_args --overwrite "$PACMAN_OVERWRITE_GLOB" $forced_packages || return 1
+  fi
+}
+
+# Check if a package is already installed
+is_installed() {
+  pacman -Q "$1" >/dev/null 2>&1
+}
+
+# Fix pacman keyring (generic Arch version based on steamos/setup.sh)
+fix_keyring() {
+  log_info "Checking pacman keyring status..."
+
+  KEYRING_OK=0
+  if sudo pacman-key --list-keys 2>/dev/null | grep -q "^pub"; then
+    KEYRING_OK=1
+  fi
+
+  if [ "$KEYRING_OK" -eq 1 ]; then
+    log_info "Pacman keyring looks healthy. Skipping keyring fix."
+    return 0
+  fi
+
+  log_info "Fixing pacman keyring..."
+
+  # Clean everything
+  sudo rm -rf /etc/pacman.d/gnupg/
+  sudo rm -rf /var/cache/pacman/pkg/*.pkg.tar.*
+
+  # Initialize and populate keyrings
+  sudo pacman-key --init
+  sudo pacman-key --populate archlinux
+
+  # Set SigLevel = TrustAll to install keyring packages
+  sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
+  sudo awk '$1 == "SigLevel" {print "SigLevel = TrustAll"; next} {print}' /etc/pacman.conf > /tmp/pacman.conf.new
+  sudo mv /tmp/pacman.conf.new /etc/pacman.conf
+
+  # Install updated keyring packages with cache cleared
+  sudo pacman -Syy --noconfirm --needed archlinux-keyring
+
+  # Re-populate with updated keys
+  sudo pacman-key --populate archlinux
+
+  # Restore original pacman.conf
+  sudo mv -f /etc/pacman.conf.bak /etc/pacman.conf
+
+  log_info "Keyring fix complete."
+}
+
+# Add Chaotic AUR and CachyOS repositories
+setup_repositories() {
+  log_info "Setting up third-party repositories..."
+
+  # Chaotic AUR
+  if ! grep -q "\[chaotic-aur\]" /etc/pacman.conf; then
+    log_info "Importing Chaotic AUR keys..."
+    echo "y" | sudo pacman-key --recv-key 3056513887B78AEB --keyserver hkp://keyserver.ubuntu.com:80
+    log_info "Signing Chaotic AUR keys..."
+    echo "y" | sudo pacman-key --lsign-key 3056513887B78AEB
+    log_info "Installing Chaotic AUR keyring and mirrorlist..."
+    sudo pacman -U --noconfirm --noprogressbar \
+      'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' \
+      'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'
+    sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
+    echo "
+[chaotic-aur]
+Include = /etc/pacman.d/chaotic-mirrorlist" | sudo tee -a /etc/pacman.conf >/dev/null
+    sudo pacman -Syy --noconfirm --noprogressbar
+  else
+    log_info "Chaotic AUR repository is already registered. Skipping..."
+  fi
+
+  # CachyOS Repository
+  if ! grep -q "\[cachyos-v3\]" /etc/pacman.conf; then
+    log_info "Importing CachyOS keys..."
+    echo "y" | sudo pacman-key --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com
+    log_info "Signing CachyOS keys..."
+    echo "y" | sudo pacman-key --lsign-key F3B607488DB35A47
+    log_info "Installing CachyOS keyring and mirrorlist..."
+    sudo pacman -U --noconfirm --noprogressbar \
+      'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-keyring-20240331-1-any.pkg.tar.zst' \
+      'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-mirrorlist-27-1-any.pkg.tar.zst' \
+      'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst' \
+      'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v4-mirrorlist-27-1-any.pkg.tar.zst'
+    sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
+    echo "
+[cachyos-v3]
+Include = /etc/pacman.d/cachyos-v3-mirrorlist
+
+[cachyos-core-v3]
+Include = /etc/pacman.d/cachyos-v3-mirrorlist
+
+[cachyos-extra-v3]
+Include = /etc/pacman.d/cachyos-v3-mirrorlist
+
+[cachyos]
+Include = /etc/pacman.d/cachyos-mirrorlist
+" | sudo tee -a /etc/pacman.conf >/dev/null
+    sudo pacman -Syy --noconfirm --noprogressbar
+  else
+    log_info "CachyOS repository is already registered. Skipping..."
+  fi
+}
+
+# Install yay (AUR helper)
+install_yay() {
+  if command -v yay >/dev/null 2>&1; then
+    log_info "yay is already installed"
+    return 0
+  fi
+
+  log_info "Installing yay..."
+
+  tmp_dir=$(mktemp -d)
+  trap "rm -rf $tmp_dir" EXIT
+
+  cd "$tmp_dir"
+  git clone https://aur.archlinux.org/yay-bin.git
+  cd yay-bin
+  # Workaround for SteamOS 3.7.x: checkout a specific commit that works with the
+  # current pacman/libalpm version. See: https://github.com/Jguer/yay/issues/2098
+  git checkout 7d1b1a155500987cd7684a4b2afd76a98b6ed922
+  makepkg -si --noconfirm
+
+  log_info "yay installed successfully"
+}
+
+# Install mandatory AUR packages
+install_aur_packages() {
+  log_info "Installing mandatory AUR packages..."
+
+  for package_name in podman-docker-git xsel ncdu rclone; do
+    if is_installed "$package_name"; then
+      log_info "$package_name is already installed"
+    else
+      log_info "Installing $package_name via yay..."
+      yay -S --noconfirm "$package_name"
+    fi
+  done
+}
+
+# Install optional extra packages (common on SteamOS 3.8.10+)
+install_extra_packages() {
+  log_info "Installing optional extra packages..."
+
+  for package_name in dmemcg-booster kcgroups plasma-foreground-booster; do
+    if is_installed "$package_name"; then
+      log_info "$package_name is already installed (SteamOS 3.8.10+ may include this)"
+    else
+      log_info "Installing $package_name..."
+      pacman_install "-S --noconfirm --noprogressbar" "$package_name"
+    fi
+  done
+}
+
+# Run the full setup chain
+run_setup() {
+  local install_optional="${1:-false}"
+
+  fix_keyring
+  setup_repositories
+  install_yay
+  install_aur_packages
+
+  if [ "$install_optional" = "true" ]; then
+    install_extra_packages
+  fi
+
+  log_info "Setup complete."
+}
+
+usage() {
+  echo "Usage: dotfiles-arch {command} [options]"
+  echo ""
+  echo "Commands:"
+  echo "  setup                Run full setup (keyring, repos, yay, AUR packages)"
+  echo "  fix-keyring          Initialize / repair pacman keyring"
+  echo "  setup-repositories   Add Chaotic AUR and CachyOS repositories"
+  echo "  install-yay          Install yay (AUR helper)"
+  echo "  install-aur-packages Install mandatory AUR packages"
+  echo "  install-extra-packages Install optional extra packages"
+  echo "  help                 Show this help message"
+  echo ""
+  echo "Options:"
+  echo "  -o, --optional       Also install optional extra packages with 'setup'"
+}
+
+main() {
+  local install_optional="false"
+  local command_arg=""
+
+  # Parse options and command (options may appear before or after the command)
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o|--optional)
+        install_optional="true"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      -*)
+        log_error "Unknown option: $1"
+        usage
+        exit 1
+        ;;
+      *)
+        if [ -z "$command_arg" ]; then
+          command_arg="$1"
+        else
+          log_error "Unexpected argument: $1"
+          usage
+          exit 1
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [ -z "$command_arg" ]; then
+    usage
+    exit 1
+  fi
+
+  case "$command_arg" in
+    setup|all)
+      run_setup "$install_optional"
+      ;;
+    fix-keyring)
+      fix_keyring
+      ;;
+    setup-repositories)
+      setup_repositories
+      ;;
+    install-yay)
+      install_yay
+      ;;
+    install-aur-packages)
+      install_aur_packages
+      ;;
+    install-extra-packages)
+      install_extra_packages
+      ;;
+    help)
+      usage
+      ;;
+    *)
+      log_error "Unknown command: $command_arg"
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
@@ -178,8 +178,8 @@ install_yay() {
   log_info "yay installed successfully"
 }
 
-# Install mandatory AUR packages
-install_aur_packages() {
+# Install mandatory packages
+install_packages() {
   log_info "Installing mandatory AUR packages..."
 
   for package_name in podman-docker-git xsel ncdu rclone; do
@@ -192,13 +192,13 @@ install_aur_packages() {
   done
 }
 
-# Install optional extra packages (common on SteamOS 3.8.10+)
-install_extra_packages() {
+# Install optional edge packages (common on SteamOS 3.8.10+ or other distros)
+install_packages_edge() {
   log_info "Installing optional extra packages..."
 
   for package_name in dmemcg-booster kcgroups plasma-foreground-booster; do
     if is_installed "$package_name"; then
-      log_info "$package_name is already installed (SteamOS 3.8.10+ may include this)"
+      log_info "$package_name is already installed (Your OS/Distro may include this)"
     else
       log_info "Installing $package_name..."
       pacman_install "-S --noconfirm --noprogressbar" "$package_name"
@@ -213,10 +213,10 @@ run_setup() {
   fix_keyring
   setup_repositories
   install_yay
-  install_aur_packages
+  install_packages
 
   if [ "$install_optional" = "true" ]; then
-    install_extra_packages
+    install_packages_edge
   fi
 
   log_info "Setup complete."
@@ -226,16 +226,16 @@ usage() {
   echo "Usage: dotfiles-arch {command} [options]"
   echo ""
   echo "Commands:"
-  echo "  setup                Run full setup (keyring, repos, yay, AUR packages)"
-  echo "  fix-keyring          Initialize / repair pacman keyring"
-  echo "  setup-repositories   Add Chaotic AUR and CachyOS repositories"
-  echo "  install-yay          Install yay (AUR helper)"
-  echo "  install-aur-packages Install mandatory AUR packages"
-  echo "  install-extra-packages Install optional extra packages"
-  echo "  help                 Show this help message"
+  echo "  setup                  Run full setup (keyring, repos, yay, packages)"
+  echo "  fix-keyring            Initialize / repair pacman keyring"
+  echo "  setup-repositories     Add Chaotic AUR and CachyOS repositories"
+  echo "  install-yay            Install yay (AUR helper)"
+  echo "  install-packages       Install mandatory packages"
+  echo "  install-packages-edge  Install optional edge packages"
+  echo "  help                   Show this help message"
   echo ""
   echo "Options:"
-  echo "  -o, --optional       Also install optional extra packages with 'setup'"
+  echo "  -o, --optional       Also install optional edge packages with 'setup'"
 }
 
 main() {
@@ -289,11 +289,11 @@ main() {
     install-yay)
       install_yay
       ;;
-    install-aur-packages)
-      install_aur_packages
+    install-packages)
+      install_packages
       ;;
-    install-extra-packages)
-      install_extra_packages
+    install-packages-edge)
+      install_packages_edge
       ;;
     help)
       usage

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
@@ -214,7 +214,7 @@ install_packages() {
   require_writeable_rootfs
   log_info "Installing mandatory packages..."
 
-  for package_name in xsel ncdu rclone; do
+  for package_name in podman-docker xsel ncdu rclone; do
     if is_installed "$package_name"; then
       log_info "$package_name is already installed"
     else

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch
@@ -59,8 +59,29 @@ is_installed() {
   pacman -Q "$1" >/dev/null 2>&1
 }
 
+# Check if the root filesystem is immutable (SteamOS)
+require_writeable_rootfs() {
+  if ! command -v steamos-readonly >/dev/null 2>&1; then
+    return 0
+  fi
+
+  set +e
+  readonly_status=$(steamos-readonly status 2>&1)
+  set -e
+
+  if echo "$readonly_status" | grep -q "enabled"; then
+    log_error "SteamOS rootfs is read-only."
+    log_error "Please make it writeable before running this command:"
+    log_error "  dotfiles-steamdeck writeable"
+    log_error "or:"
+    log_error "  sudo steamos-readonly disable"
+    return 1
+  fi
+}
+
 # Fix pacman keyring (generic Arch version based on steamos/setup.sh)
 fix_keyring() {
+  require_writeable_rootfs
   log_info "Checking pacman keyring status..."
 
   KEYRING_OK=0
@@ -102,6 +123,7 @@ fix_keyring() {
 
 # Add Chaotic AUR and CachyOS repositories
 setup_repositories() {
+  require_writeable_rootfs
   log_info "Setting up third-party repositories..."
 
   # Chaotic AUR
@@ -157,12 +179,21 @@ Include = /etc/pacman.d/cachyos-mirrorlist
 
 # Install yay (AUR helper)
 install_yay() {
+  require_writeable_rootfs
   if command -v yay >/dev/null 2>&1; then
     log_info "yay is already installed"
     return 0
   fi
 
   log_info "Installing yay..."
+
+  # SteamOS 3.8.10+ removed debugedit and fakeroot, which are required by makepkg.
+  for pkg in debugedit fakeroot; do
+    if ! is_installed "$pkg"; then
+      log_info "Installing $pkg (required to build yay on SteamOS 3.8.10+)..."
+      sudo pacman -S --noconfirm --needed "$pkg"
+    fi
+  done
 
   tmp_dir=$(mktemp -d)
   trap "rm -rf $tmp_dir" EXIT
@@ -180,9 +211,10 @@ install_yay() {
 
 # Install mandatory packages
 install_packages() {
-  log_info "Installing mandatory AUR packages..."
+  require_writeable_rootfs
+  log_info "Installing mandatory packages..."
 
-  for package_name in podman-docker-git xsel ncdu rclone; do
+  for package_name in xsel ncdu rclone; do
     if is_installed "$package_name"; then
       log_info "$package_name is already installed"
     else
@@ -194,6 +226,7 @@ install_packages() {
 
 # Install optional edge packages (common on SteamOS 3.8.10+ or other distros)
 install_packages_edge() {
+  require_writeable_rootfs
   log_info "Installing optional extra packages..."
 
   for package_name in dmemcg-booster kcgroups plasma-foreground-booster; do

--- a/linux/zsh/.zsh/completions/_dotfiles-arch
+++ b/linux/zsh/.zsh/completions/_dotfiles-arch
@@ -1,0 +1,36 @@
+#compdef dotfiles-arch
+
+# Zsh completion for dotfiles-arch
+
+_dotfiles-arch() {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments -C \
+    '(-o --optional)'{-o,--optional}'[Also install optional edge packages with setup]' \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '1: :->command' \
+    '*:: :->args'
+
+  case "$state" in
+    command)
+      _values 'dotfiles-arch command' \
+        'setup[Run full setup]' \
+        'fix-keyring[Initialize or repair pacman keyring]' \
+        'setup-repositories[Add Chaotic AUR and CachyOS repositories]' \
+        'install-yay[Install yay (AUR helper)]' \
+        'install-packages[Install mandatory packages]' \
+        'install-packages-edge[Install optional edge packages]' \
+        'help[Show help]'
+      ;;
+    args)
+      case "$line[1]" in
+        setup|all)
+          _arguments '(-o --optional)'{-o,--optional}'[Also install optional edge packages]'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_dotfiles-arch "$@"

--- a/linux/zsh/.zshrc
+++ b/linux/zsh/.zshrc
@@ -179,6 +179,7 @@ setopt pushd_ignore_dups
 setopt pushdminus
 
 # Completion.
+fpath+=($HOME/.zsh/completions)
 autoload -Uz compinit
 compinit
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'       # Case insensitive tab completion


### PR DESCRIPTION
Closes #201

## Summary

Introduces `dotfiles-arch`, a new Arch-specific utility for AUR repository setup, keyring repair, and package installation. `arch/setup.sh` is stripped down to focus on general system setup.

## Changes

### New script

`linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-arch`

| Command | Description |
|---------|-------------|
| `setup` / `all` | Full chain: keyring → repositories → yay → packages |
| `fix-keyring` | Repair pacman keyring (generic Arch) |
| `setup-repositories` | Add Chaotic AUR and CachyOS repositories |
| `install-yay` | Build and install `yay-bin` |
| `install-packages` | Install mandatory packages |
| `install-packages-edge` | Install optional edge packages |
| `help` | Show usage |

Mandatory packages: `podman-docker`, `xsel`, `ncdu`, `rclone`

Edge packages: `dmemcg-booster`, `kcgroups`, `plasma-foreground-booster`

- Use `dotfiles-arch setup -o` or `dotfiles-arch --optional setup` to include edge packages.
- All steps are idempotent (checks existing repos / installed packages before acting).
- On SteamOS, mutating commands check `steamos-readonly status` first and exit with instructions if the rootfs is read-only.
- `install-yay` installs `debugedit` and `fakeroot` if missing, since SteamOS 3.8.10+ removed them but `makepkg` requires them to build `yay-bin`.

### Updated

- `arch/setup.sh`
  - Removed migrated logic: pacman keyring fix, Chaotic/CachyOS repository setup, `yay` installation, packages, and edge packages.
  - Kept general system setup: locale, essential packages, `ccache`, `xclip`, `rankmirrors` / `reflector`.

### Added

- Zsh tab completion for `dotfiles-arch`
  - `linux/zsh/.zsh/completions/_dotfiles-arch`
  - `linux/zsh/.zshrc` now adds `~/.zsh/completions` to `fpath` before `compinit`.

## Notes

- SteamOS-specific handling (`steamos-readonly`, `holo` keyring) remains in `dotfiles-steamdeck` / `steamos/setup.sh`.
- `start.sh` is unchanged; `dotfiles-arch` is run separately when AUR setup is needed.