### PR TITLE
Add missing python header dependencies for Fedora

### DIFF
--- a/linux/bash/.bashrc.d/01-nvm
+++ b/linux/bash/.bashrc.d/01-nvm
@@ -1,0 +1,6 @@
+# NVM via Homebrew — load early before any Homebrew node
+# This file is intentionally placed after 00-env so NVM_DIR is already set
+if command -v brew >/dev/null 2>&1; then
+  [ -s "$(brew --prefix nvm)/nvm.sh" ] && \. "$(brew --prefix nvm)/nvm.sh"
+  [ -s "$(brew --prefix nvm)/etc/bash_completion.d/nvm" ] && \. "$(brew --prefix nvm)/etc/bash_completion.d/nvm"
+fi

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-nodejs
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-nodejs
@@ -17,19 +17,61 @@ DEFAULT_NODE_VERSION="22"
 
 # ─── Helper functions ──────────────────────────────────────────────────────────
 
-# Ensure NVM is loaded in current shell
-_load_nvm() {
-    if [ -s "$NVM_DIR/nvm.sh" ]; then
-        # Temporarily disable 'set -u' to allow NVM's internal variable initialization
-        # NVM uses '_' for internal state tracking which may not be set in CI environments
-        set +u
-        . "$NVM_DIR/nvm.sh"
-        set -u
+# Try to locate brew binary and set up its environment
+_ensure_brew_env() {
+    if command -v brew >/dev/null 2>&1; then
+        return 0
+    fi
+    # Homebrew may be installed but not on PATH yet (common in CI).
+    # Check known locations and source shellenv.
+    local brew_path=""
+    for candidate in \
+        /home/linuxbrew/.linuxbrew/bin/brew \
+        "$HOME/.linuxbrew/bin/brew" \
+        /usr/local/bin/brew \
+        /opt/homebrew/bin/brew
+    do
+        if [ -x "$candidate" ]; then
+            brew_path="$candidate"
+            break
+        fi
+    done
+    if [ -n "$brew_path" ]; then
+        eval "$("$brew_path" shellenv)"
     fi
 }
 
-# Check if NVM is installed
+# Determine NVM prefix from Homebrew or fallback
+_nvm_prefix() {
+    _ensure_brew_env
+    if command -v brew >/dev/null 2>&1; then
+        brew --prefix nvm 2>/dev/null
+    fi
+}
+
+# Ensure NVM is loaded in current shell
+_load_nvm() {
+    local nvm_prefix="$(_nvm_prefix)"
+    if [ -n "$nvm_prefix" ] && [ -s "$nvm_prefix/nvm.sh" ]; then
+        # Temporarily disable 'set -e' and 'set -u' while loading NVM.
+        # NVM's internal scripts are not designed for strict mode and will
+        # abort on Fedora/RHEL CI if errexit/nounset are active.
+        set +eu
+        . "$nvm_prefix/nvm.sh"
+        set -eu
+    elif [ -s "$NVM_DIR/nvm.sh" ]; then
+        set +eu
+        . "$NVM_DIR/nvm.sh"
+        set -eu
+    fi
+}
+
+# Check if NVM is installed (via Homebrew or manual)
 _nvm_installed() {
+    local nvm_prefix="$(_nvm_prefix)"
+    if [ -n "$nvm_prefix" ] && [ -s "$nvm_prefix/nvm.sh" ]; then
+        return 0
+    fi
     [ -d "$NVM_DIR" ] && [ -s "$NVM_DIR/nvm.sh" ]
 }
 
@@ -52,29 +94,40 @@ _download_with_retry() {
 
 # ─── Actions ───────────────────────────────────────────────────────────────────
 
-# Install NVM
+# Install NVM via Homebrew (preferred) or fallback to curl install
 action_install_nvm() {
-    echo "[nodejs] Installing NVM $NVM_VERSION..."
-    
     if _nvm_installed; then
-        echo "[nodejs] NVM already installed at $NVM_DIR"
+        echo "[nodejs] NVM already installed"
         return 0
     fi
 
-    # Create NVM directory
-    mkdir -p "$NVM_DIR"
-
-    # Download and run install script using bash (NOT zsh!)
-    local install_url="https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh"
-    
-    if ! _download_with_retry "$install_url" | bash; then
-        echo "[nodejs] ERROR: NVM installation failed. Check network connectivity."
-        return 1
+    # Prefer Homebrew if available
+    _ensure_brew_env
+    if command -v brew >/dev/null 2>&1; then
+        echo "[nodejs] Installing NVM via Homebrew..."
+        if ! brew install nvm; then
+            echo "[nodejs] ERROR: Homebrew NVM installation failed."
+            return 1
+        fi
+        
+        # Ensure NVM_DIR directory exists for node installations
+        mkdir -p "$NVM_DIR"
+        
+        # NOTE: NVM initialization is already included in the tracked dotfiles
+        # (.zshrc and linux/bash/.bashrc.d/01-nvm), so no shell profile modification needed.
+    else
+        # Fallback: manual curl install
+        echo "[nodejs] Installing NVM $NVM_VERSION via install script..."
+        mkdir -p "$NVM_DIR"
+        local install_url="https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh"
+        if ! _download_with_retry "$install_url" | bash; then
+            echo "[nodejs] ERROR: NVM installation failed. Check network connectivity."
+            return 1
+        fi
     fi
 
     # Reload profile to pick up NVM initialization
     if [ -f "$HOME/.bashrc" ]; then
-        # Source bashrc but capture errors for debugging
         if ! . "$HOME/.bashrc" 2>/dev/null; then
             echo "[nodejs] WARNING: Failed to source ~/.bashrc, but NVM files may still be present"
         fi
@@ -82,7 +135,7 @@ action_install_nvm() {
 
     # Verify installation
     if _nvm_installed; then
-        echo "[nodejs] NVM installed successfully to $NVM_DIR"
+        echo "[nodejs] NVM installed successfully"
     else
         echo "[nodejs] ERROR: NVM installation verification failed."
         return 1
@@ -108,15 +161,23 @@ action_install_node() {
         return 1
     fi
 
-    # Install Node version
-    if nvm install "$version"; then
+    # Disable strict mode while running NVM commands.
+    # NVM's install/use internals are not compatible with errexit.
+    set +eu
+    local nvm_exit=0
+    if ! nvm install "$version"; then
+        nvm_exit=1
+    fi
+    if [ "$nvm_exit" -eq 0 ]; then
         echo "[nodejs] Node.js v${version} installed successfully"
         nvm use "$version" 2>/dev/null || true
+        nvm alias default "$version" 2>/dev/null || true
         echo "[nodejs] Current: $(node --version 2>/dev/null || echo 'unknown')"
     else
         echo "[nodejs] ERROR: Failed to install Node.js v${version}"
-        return 1
     fi
+    set -eu
+    return "$nvm_exit"
 }
 
 # List installed Node versions
@@ -138,17 +199,30 @@ action_uninstall_nvm() {
         return 0
     fi
 
-    printf "[nodejs] Remove NVM from %s? [y/N]: " "$NVM_DIR"
+    local nvm_prefix="$(_nvm_prefix)"
+    if [ -n "$nvm_prefix" ]; then
+        printf "[nodejs] Uninstall NVM via Homebrew? [y/N]: "
+    else
+        printf "[nodejs] Remove NVM from %s? [y/N]: " "$NVM_DIR"
+    fi
     read confirm
     if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+        if [ -n "$nvm_prefix" ]; then
+            brew uninstall nvm 2>/dev/null || true
+        fi
+        
         # Remove NVM directory
         rm -rf "$NVM_DIR"
         
-        # Remove from bashrc/zshrc if we added it
-        if [ -f "$HOME/.bashrc" ]; then
-            sed -i '/export NVM_DIR=.*\.nvm/d' "$HOME/.bashrc" 2>/dev/null || true
-            sed -i '/\..*nvm\.sh/d' "$HOME/.bashrc" 2>/dev/null || true
-        fi
+        # Remove from bashrc/zshrc
+        for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+            if [ -f "$rc" ]; then
+                sed -i '/export NVM_DIR=.*\.nvm/d' "$rc" 2>/dev/null || true
+                sed -i '/\..*nvm\.sh/d' "$rc" 2>/dev/null || true
+                sed -i '/# NVM via Homebrew/d' "$rc" 2>/dev/null || true
+                sed -i '/brew --prefix nvm/d' "$rc" 2>/dev/null || true
+            fi
+        done
         
         echo "[nodejs] NVM uninstalled."
     else

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-nodejs
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-nodejs
@@ -17,62 +17,53 @@ DEFAULT_NODE_VERSION="22"
 
 # ─── Helper functions ──────────────────────────────────────────────────────────
 
-# Try to locate brew binary and set up its environment
-_ensure_brew_env() {
-    if command -v brew >/dev/null 2>&1; then
-        return 0
+# Ensure Homebrew is on PATH (mirrors dotfiles-php pattern)
+_ensure_brew() {
+  if command -v brew >/dev/null 2>&1; then
+    return 0
+  fi
+  for brew_bin in \
+    "${HOMEBREW_PREFIX:-}/bin/brew" \
+    "${HOME}/.linuxbrew/bin/brew" \
+    "/home/linuxbrew/.linuxbrew/bin/brew" \
+    "/usr/local/bin/brew" \
+    "/opt/homebrew/bin/brew"
+  do
+    if [ -x "$brew_bin" ]; then
+      eval "$("$brew_bin" shellenv)"
+      break
     fi
-    # Homebrew may be installed but not on PATH yet (common in CI).
-    # Check known locations and source shellenv.
-    local brew_path=""
-    for candidate in \
-        /home/linuxbrew/.linuxbrew/bin/brew \
-        "$HOME/.linuxbrew/bin/brew" \
-        /usr/local/bin/brew \
-        /opt/homebrew/bin/brew
-    do
-        if [ -x "$candidate" ]; then
-            brew_path="$candidate"
-            break
-        fi
-    done
-    if [ -n "$brew_path" ]; then
-        eval "$("$brew_path" shellenv)"
-    fi
+  done
 }
 
-# Determine NVM prefix from Homebrew or fallback
-_nvm_prefix() {
-    _ensure_brew_env
-    if command -v brew >/dev/null 2>&1; then
-        brew --prefix nvm 2>/dev/null
-    fi
-}
-
-# Ensure NVM is loaded in current shell
+# Load NVM into current shell
 _load_nvm() {
-    local nvm_prefix="$(_nvm_prefix)"
+  set +eu
+  if command -v brew >/dev/null 2>&1; then
+    local nvm_prefix
+    nvm_prefix="$(brew --prefix nvm 2>/dev/null || true)"
     if [ -n "$nvm_prefix" ] && [ -s "$nvm_prefix/nvm.sh" ]; then
-        # Temporarily disable 'set -e' and 'set -u' while loading NVM.
-        # NVM's internal scripts are not designed for strict mode and will
-        # abort on Fedora/RHEL CI if errexit/nounset are active.
-        set +eu
-        . "$nvm_prefix/nvm.sh"
-        set -eu
-    elif [ -s "$NVM_DIR/nvm.sh" ]; then
-        set +eu
-        . "$NVM_DIR/nvm.sh"
-        set -eu
+      . "$nvm_prefix/nvm.sh"
+      set -eu
+      return 0
     fi
+  fi
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    . "$NVM_DIR/nvm.sh"
+  fi
+  set -eu
 }
 
-# Check if NVM is installed (via Homebrew or manual)
+# Check if NVM is installed
 _nvm_installed() {
-    local nvm_prefix="$(_nvm_prefix)"
+  if command -v brew >/dev/null 2>&1; then
+    local nvm_prefix
+    nvm_prefix="$(brew --prefix nvm 2>/dev/null || true)"
     if [ -n "$nvm_prefix" ] && [ -s "$nvm_prefix/nvm.sh" ]; then
-        return 0
+      return 0
     fi
-    [ -d "$NVM_DIR" ] && [ -s "$NVM_DIR/nvm.sh" ]
+  fi
+  [ -d "$NVM_DIR" ] && [ -s "$NVM_DIR/nvm.sh" ]
 }
 
 # Download with retry logic
@@ -94,42 +85,25 @@ _download_with_retry() {
 
 # ─── Actions ───────────────────────────────────────────────────────────────────
 
-# Install NVM via Homebrew (preferred) or fallback to curl install
+# Install NVM
 action_install_nvm() {
     if _nvm_installed; then
         echo "[nodejs] NVM already installed"
         return 0
     fi
 
-    # Prefer Homebrew if available
-    _ensure_brew_env
+    _ensure_brew
     if command -v brew >/dev/null 2>&1; then
         echo "[nodejs] Installing NVM via Homebrew..."
-        if ! brew install nvm; then
-            echo "[nodejs] ERROR: Homebrew NVM installation failed."
-            return 1
-        fi
-        
-        # Ensure NVM_DIR directory exists for node installations
+        brew install nvm
         mkdir -p "$NVM_DIR"
-        
-        # NOTE: NVM initialization is already included in the tracked dotfiles
-        # (.zshrc and linux/bash/.bashrc.d/01-nvm), so no shell profile modification needed.
     else
-        # Fallback: manual curl install
         echo "[nodejs] Installing NVM $NVM_VERSION via install script..."
         mkdir -p "$NVM_DIR"
         local install_url="https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh"
         if ! _download_with_retry "$install_url" | bash; then
             echo "[nodejs] ERROR: NVM installation failed. Check network connectivity."
             return 1
-        fi
-    fi
-
-    # Reload profile to pick up NVM initialization
-    if [ -f "$HOME/.bashrc" ]; then
-        if ! . "$HOME/.bashrc" 2>/dev/null; then
-            echo "[nodejs] WARNING: Failed to source ~/.bashrc, but NVM files may still be present"
         fi
     fi
 
@@ -145,9 +119,9 @@ action_install_nvm() {
 # Install Node.js version (default: LTS)
 action_install_node() {
     local version="${1:-$DEFAULT_NODE_VERSION}"
-    
+
     echo "[nodejs] Installing Node.js v${version}..."
-    
+
     if ! _nvm_installed; then
         echo "[nodejs] NVM not found. Installing NVM first..."
         action_install_nvm || return 1
@@ -161,8 +135,7 @@ action_install_node() {
         return 1
     fi
 
-    # Disable strict mode while running NVM commands.
-    # NVM's install/use internals are not compatible with errexit.
+    # Disable strict mode while running NVM commands
     set +eu
     local nvm_exit=0
     if ! nvm install "$version"; then
@@ -199,21 +172,30 @@ action_uninstall_nvm() {
         return 0
     fi
 
-    local nvm_prefix="$(_nvm_prefix)"
-    if [ -n "$nvm_prefix" ]; then
+    local via_brew=""
+    _ensure_brew
+    if command -v brew >/dev/null 2>&1; then
+      local nvm_prefix
+      nvm_prefix="$(brew --prefix nvm 2>/dev/null || true)"
+      if [ -n "$nvm_prefix" ] && [ -s "$nvm_prefix/nvm.sh" ]; then
+        via_brew=1
+      fi
+    fi
+
+    if [ -n "$via_brew" ]; then
         printf "[nodejs] Uninstall NVM via Homebrew? [y/N]: "
     else
         printf "[nodejs] Remove NVM from %s? [y/N]: " "$NVM_DIR"
     fi
     read confirm
     if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
-        if [ -n "$nvm_prefix" ]; then
+        if [ -n "$via_brew" ]; then
             brew uninstall nvm 2>/dev/null || true
         fi
-        
+
         # Remove NVM directory
         rm -rf "$NVM_DIR"
-        
+
         # Remove from bashrc/zshrc
         for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
             if [ -f "$rc" ]; then
@@ -223,7 +205,7 @@ action_uninstall_nvm() {
                 sed -i '/brew --prefix nvm/d' "$rc" 2>/dev/null || true
             fi
         done
-        
+
         echo "[nodejs] NVM uninstalled."
     else
         echo "[nodejs] Cancelled."
@@ -238,24 +220,24 @@ action_update_nvm() {
     fi
 
     _load_nvm
-    
+
     local latest
     latest=$(nvm --version 2>/dev/null || echo "unknown")
     echo "[nodejs] Current NVM version: $latest"
     echo "[nodejs] Fetching latest version info..."
-    
+
     # Get latest tag from GitHub
     local latest_tag
     latest_tag=$(curl -fsSL "https://api.github.com/repos/nvm-sh/nvm/releases/latest" 2>/dev/null | \
         grep '"tag_name"' | sed 's/.*"tag_name": "\(.*\)".*/\1/' || echo "")
-    
+
     if [ -z "$latest_tag" ]; then
         echo "[nodejs] ERROR: Could not fetch latest NVM version."
         return 1
     fi
 
     echo "[nodejs] Latest version: $latest_tag"
-    
+
     if [ "$latest" = "${latest_tag#v}" ]; then
         echo "[nodejs] Already up to date."
         return 0
@@ -266,12 +248,12 @@ action_update_nvm() {
     if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
         # Re-run install script with new version
         local install_url="https://raw.githubusercontent.com/nvm-sh/nvm/${latest_tag}/install.sh"
-        
+
         if ! _download_with_retry "$install_url" | bash; then
             echo "[nodejs] ERROR: NVM update failed."
             return 1
         fi
-        
+
         echo "[nodejs] NVM updated to $latest_tag"
     else
         echo "[nodejs] Cancelled."
@@ -341,7 +323,7 @@ run_wizard() {
 
 main() {
     local cmd="${1:-}"
-    
+
     case "$cmd" in
         install)
             action_install_nvm

--- a/linux/zsh/.zshrc
+++ b/linux/zsh/.zshrc
@@ -1,3 +1,10 @@
+# NVM via Homebrew — load early before any Homebrew node
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if command -v brew >/dev/null 2>&1; then
+  [ -s "$(brew --prefix nvm)/nvm.sh" ] && \. "$(brew --prefix nvm)/nvm.sh"
+  [ -s "$(brew --prefix nvm)/etc/bash_completion.d/nvm" ] && \. "$(brew --prefix nvm)/etc/bash_completion.d/nvm"
+fi
+
 # Path to your oh-my-zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
 

--- a/rhel/setup.sh
+++ b/rhel/setup.sh
@@ -13,6 +13,7 @@ sudo dnf install -y rclone
 
 # Python
 sudo dnf install -y python2 python3 libssh-devel libgcrypt libgcrypt-devel tk-devel tc-devel
+sudo dnf install -y bzip2-devel ncurses-devel libffi-devel readline-devel openssl-devel xz-devel libuuid-devel gdbm-libs libnsl2
 sudo dnf install -y python3-tmuxp python3-packaging python3-pip python3-virtualenv
 
 # PHP


### PR DESCRIPTION
Includes fixes for `nodejs`.

Closes #203 #199 