### PR TITLE
More Flatpak configurations

### DIFF
--- a/linux/flatpak/.var/app/io.mpv.Mpv/config/mpv/mpv.conf
+++ b/linux/flatpak/.var/app/io.mpv.Mpv/config/mpv/mpv.conf
@@ -1,0 +1,9 @@
+fs=no
+save-position-on-quit=yes
+hwdec=auto
+no-keepaspect-window=yes
+geometry=50%x50%
+contextmenu=yes
+autofit-geometry=854x480
+gpu-context=x11egl
+


### PR DESCRIPTION
Add the following configurations for Flatpak:

- [x] ~~mpv~~ — superseded by #220 (native + Flatpak installs now share one `mpv-config` submodule via a symlink in the `linux/mpv` stow package instead of a separate hand-written conf here)
- [ ] VLC Media Player
- [ ] Bottles
- [ ] nomacs
- [ ] Vesktop (Startup)
- [ ] Bitwarden (Startup)