### PR TITLE
docs(claude): add AI usage policy, commit, review, and memory rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,14 @@
 # AI Coding Agent Instructions for .dotfiles
 
+## Companion Instruction Files
+
+Before starting any task, also read the `CLAUDE.md`/`AGENTS.md` files in this repository for reference or additional information:
+
+- `CLAUDE.md` (repo root) — condensed commands, architecture, and conventions
+- `linux/systems/.local/bin/org.jcchikikomori.dotfiles/CLAUDE.md` — agent notes for the utility-script directory (e.g. `dotfiles-arch` reference, AUR safety-research requirement)
+- `.github/agents/dotfiles-maintainer.agent.md` — cross-platform maintenance agent workflow
+- Any other `CLAUDE.md`/`AGENTS.md` found in a directory you are working in takes precedence for that directory
+
 ## Project Overview
 
 This is a cross-platform dotfiles management system that automates shell and development environment setup across multiple Linux distributions (Debian/Ubuntu, Arch, RHEL/Fedora, SteamOS). It uses **GNU Stow** via the [dotstow](https://github.com/jcchikikomori/dotstow) wrapper to symlink configuration files from `linux/*/` directories to `$HOME`.

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,10 @@ linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/starship
 # Ignore all files and directories within ~/.gnupg
 linux/gpg/.gnupg/*
 
-# But track gpg.conf and gpg-agent.conf
+# But track gpg.conf, gpg-agent.conf, and agent notes
 !linux/gpg/.gnupg/gpg.conf
 !linux/gpg/.gnupg/gpg-agent.conf
+!linux/gpg/.gnupg/CLAUDE.md
 
 # VSCode
 /.vscode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Cross-platform dotfiles management system. Automates shell/dev environment setup across Debian/Ubuntu, Arch (incl. SteamOS), RHEL/Fedora, macOS, WSL2, and Termux. Configs are symlinked from `linux/*/` package directories into `$HOME` using GNU Stow via the [dotstow](https://github.com/jcchikikomori/dotstow) wrapper.
+
+**Hardcoded paths — do not change:**
+
+- Repo location: `$HOME/.dotfiles`
+- Utility scripts: `linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/` (stowed to `$HOME/.local/bin/...`)
+- Dev tools: `linux/systems/.local/bin/org.jcchikikomori.devtools/bin/`
+- Dotstow state: `$HOME/.local/state/dotstow/dotfiles` → symlink to `$HOME/.dotfiles`
+
+## Commands
+
+```sh
+# Full setup (fresh machine) — order matters
+git submodule update --init --recursive   # required; stow fails on submodule packages otherwise
+./start.sh                                # OS detection → {distro}/setup.sh → dotfiles-post-setup
+./stowme.sh                               # symlink configs via dotstow (canonical entrypoint)
+
+# Run/test a single post-setup script (same as CI does)
+./linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-python install
+./linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-nodejs install
+
+# Debian smoke test in Docker (stow workflow end-to-end)
+docker compose run --rm dotfiles-ci-debian
+
+# Lint/format (pre-commit: check-yaml, whitespace, json, black)
+pre-commit run --all-files
+```
+
+There is no unit-test framework. Validation happens through GitHub Actions integration tests (`.github/workflows/ci-unit-test.yml` for ubuntu/arch/fedora, `ci-termux.yml` for simulated Termux) and the Docker smoke test above. CI env vars: `SKIP_SETTING_USER=true`, `SKIP_INSTALL_PROGLANG=false`, `CI=true`.
+
+Commit messages must be conventional-commit format (commitizen enforces via `commit-msg` hook; `cz commit` for a wizard).
+
+## Architecture
+
+**Two-phase setup flow:**
+
+1. `start.sh` — detects distro (writes `$HOME/.dotfiles-distro`; values: `ubuntu`, `debian`, `arch`, `archbtw`, `steamos`, `rhel`, `darwin`, `termux`), runs `{distro}/setup.sh`, then `dotfiles-post-setup` (interactive prompts for pyenv/nvm/rbenv/sdkman etc., skipped when `SKIP_INSTALL_PROGLANG` set).
+2. `stowme.sh` — pre-stow cleanup (`dotfiles-cleanup`, `dotfiles-cleanup-bin`, `dotfiles-ssh`, `dotfiles-conflicts`), then `dotstow stow <packages>`. Root `stowme.sh` owns the **only canonical package list** (with a reduced list for `darwin`); `{distro}/stowme.sh` files are compatibility wrappers that must only delegate to root. Handles WSL/CI absolute-symlink traps (`~/.aws`, `~/.azure`, `~/.ghcup`) by removing and restoring them around stow.
+
+**Stow packages** map 1:1 to `linux/{name}/` directories whose internal layout mirrors `$HOME` (e.g. `linux/zsh/.zshrc`). Adding a config: create `linux/{package}/`, add the package name to root `stowme.sh`. Full list in `docs/STOW_PACKAGES.md`.
+
+**Git submodules** (init required before stowing): `linux/opencode`, `linux/claude`, `linux/vscode/.config/Code/User/prompts`.
+
+**Distro family propagation:** changes to setup logic usually need mirroring across families — Debian (`debian/`, `ubuntu/`), Arch (`arch/`, `steamos/`), RHEL (`rhel/`), macOS (`darwin/`), Termux (`termux/`). `archbtw` (barebones Arch) additionally runs `arch/init.sh` first (locale, base-devel, yay, Chaotic-AUR).
+
+**Termux constraints:** no sudo, no systemd, `pkg` package manager, `$PREFIX` paths, Bionic libc — only Python/pyenv officially supported there.
+
+## Scripting Conventions
+
+- **POSIX `#!/bin/sh` only** — no bashisms (scripts must run on dash, Termux, macOS sh).
+- Utility naming: `dotfiles-{purpose}`; start new scripts from `bin/bin-template` in the same directory.
+- **Never rename existing script files** — names are referenced by `dotfiles-post-setup` and CI workflows.
+- Keep `SKIP_INSTALL_PROGLANG` unattended-mode checks and the `install` argument support intact in version-manager scripts (CI depends on both).
+- Interactive prompts must have a non-interactive escape hatch for CI.
+
+## Directory-Specific Notes
+
+- `linux/systems/.local/bin/org.jcchikikomori.dotfiles/CLAUDE.md` — agent notes for the utility-script directory (e.g. `dotfiles-arch` command reference, AUR safety-research requirement).
+- `docs/MCP_GITHUB_POLICY.md` — GitHub operations default to GitHub MCP tools; `gh` CLI is fallback only.
+- `.github/copilot-instructions.md` — extended agent instructions (CI patterns, Termux gotchas, tmux/zsh plugin stack details).

--- a/linux/flatpak/.config/autostart/CLAUDE.md
+++ b/linux/flatpak/.config/autostart/CLAUDE.md
@@ -1,0 +1,24 @@
+# Flatpak Autostart Entries
+
+`.desktop` files here are stowed to `~/.config/autostart/` and launched by the desktop environment at login. Each one starts a Flatpak app (Bitwarden, Discord, Vesktop).
+
+## Adding a new autostart entry
+
+1. Name the file after the Flatpak app ID: `<app.id>.desktop` (e.g. `com.bitwarden.desktop.desktop`).
+2. Minimum required keys:
+
+```ini
+[Desktop Entry]
+Exec=flatpak run <app.id>
+Name=<app.id>
+Type=Application
+X-Flatpak=<app.id>
+```
+
+1. Prefer copying the app's own desktop entry from `/var/lib/flatpak/exports/share/applications/<app.id>.desktop` and adding flags like `--start-minimized` to `Exec` — see the Discord/Vesktop entries for the full-metadata pattern.
+
+## Notes for agents
+
+- These entries assume the app is already installed via Flatpak; installation itself is not handled by this package.
+- Chat apps here intentionally use `--start-minimized` so login isn't interrupted.
+- Removing a file only stops autostart; it does not uninstall the app.

--- a/linux/git/.config/git/CLAUDE.md
+++ b/linux/git/.config/git/CLAUDE.md
@@ -1,0 +1,31 @@
+# Git Package
+
+The `git` stow package ships three files into `$HOME`: `.gitconfig`, `.gitignore`, and `.pre-commit-config.yaml`. This note lives in `~/.config/git/` because the package root maps directly to `$HOME`.
+
+## Identity switching (`.gitconfig`)
+
+Two named identities are defined as `[user "work"]` and `[user "personal"]` sections, each with its own noreply email and GPG signing key. Switch the active identity per-repo with the alias:
+
+```sh
+git identity work      # copies user.work.* into user.name/email/signingkey
+git identity personal
+```
+
+Default (top-level `[user]`) is the personal identity.
+
+## Signing
+
+- `commit.gpgsign = true` — all commits are GPG-signed, everywhere. Do not disable it to "fix" a failing commit; fix the GPG/pinentry setup instead (see the `gpg` package notes in `~/.gnupg/CLAUDE.md`).
+- `git lsa` alias shows the log with signatures for verification.
+
+## Other conventions baked in
+
+- `pull.rebase = true` — pulls rebase, never merge.
+- `credential.helper` points at the Windows Git Credential Manager path — WSL-specific; harmless elsewhere but expect it to be a no-op outside WSL.
+- Git LFS filters are pre-configured and `required`.
+- `~/.pre-commit-config.yaml` is the fallback pre-commit config (commitizen conventional-commit checks, whitespace/yaml/json hygiene, black) for repos without their own.
+
+## Notes for agents
+
+- Editing `~/.gitconfig` edits this repo's `linux/git/.gitconfig` through the stow symlink — treat it as versioned config, not a scratch file.
+- Never change signing keys or identity emails without explicit user request.

--- a/linux/gpg/.gnupg/CLAUDE.md
+++ b/linux/gpg/.gnupg/CLAUDE.md
@@ -1,0 +1,12 @@
+# GnuPG Package
+
+Stowed to `~/.gnupg/`. Two small files that exist for one purpose: make GPG commit signing work in terminals, WSL, and headless sessions.
+
+- `gpg.conf` — `use-agent` + `pinentry-mode loopback` (passphrase goes through the agent loopback instead of a GUI pinentry popup).
+- `gpg-agent.conf` — `pinentry-program /usr/bin/pinentry-tty` + `allow-loopback-pinentry` (required for the loopback mode above to be accepted by the agent).
+
+## Notes for agents
+
+- These settings pair with `commit.gpgsign = true` in the `git` package — if commit signing breaks, check this pinentry chain first (`gpg-connect-agent reloadagent /bye` after edits).
+- `pinentry-tty` requires a usable TTY; GUI-only contexts need a different pinentry program — change `pinentry-program`, don't remove loopback support.
+- Keyrings, private keys, and trust databases are **not** part of this package — only these two config files are versioned. Never add key material here.

--- a/linux/lindbergh/.config/lindbergh-loader/CLAUDE.md
+++ b/linux/lindbergh/.config/lindbergh-loader/CLAUDE.md
@@ -1,0 +1,25 @@
+# SEGA Lindbergh Loader Config
+
+Stowed to `~/.config/lindbergh-loader/`. Used by the Lindbergh Loader AppImage to run SEGA Lindbergh arcade games (Initial D 4/5, OutRun 2) — primarily on Steam Deck.
+
+## Layout
+
+- `configs/lindbergh.ini` — base emulator config (display, input mode, region). Reference copy; games load an explicit config via `--config`.
+- `configs/<game>.ini` — per-game config override (e.g. `initiald.ini`).
+- `controls/default.ini` — fallback control mapping.
+- `controls/<game>.ini` — per-game control mapping.
+
+## How games are launched
+
+```sh
+"$HOME/AppImages/lindbergh_loader.appimage" \
+  --gamepath "$HOME/Games/Lindbergh/<romdir>" \
+  --config   "$HOME/.config/lindbergh-loader/configs/<game>.ini" \
+  --controls "$HOME/.config/lindbergh-loader/controls/<game>.ini"
+```
+
+## Notes for agents
+
+- Hardcoded expectations: dumped games in `~/Games/Lindbergh/`, loader AppImage at `~/AppImages/lindbergh_loader.appimage` (Flatpak/binary builds of the loader were unstable — AppImage only).
+- Adding a game: add `configs/<game>.ini` + `controls/<game>.ini` here, then a matching `lindbergh-<game>` launcher (plus `-test` variant) in the `systems` package.
+- `.ini` comments in `lindbergh.ini` document each option — keep them when editing.

--- a/linux/systems/.local/bin/org.jcchikikomori.devtools/AGENTS.md
+++ b/linux/systems/.local/bin/org.jcchikikomori.devtools/AGENTS.md
@@ -1,0 +1,43 @@
+# Agent Notes: devtools-bin
+
+Developer tooling scripts, separate from the `org.jcchikikomori.dotfiles` setup utilities next door. Naming convention: `devtools-{purpose}`. All POSIX `#!/bin/sh` unless noted.
+
+## Scripts
+
+### `bin/devtools-opencode`
+
+Unified OpenCode setup and management. The most load-bearing script here — invoked by `stowme.sh` (omo restore) and CI (`install`, MCP binary verification).
+
+```text
+install / update     Install or update opencode and MCP dependencies
+sync                 Sync shared AI agent configs (shared/ai-agents/) to OpenCode
+mcp [install|list|status]                      Manage MCP dependencies (pipx/npx binaries)
+vscode [generate|apply|list|project|install]   VSCode MCP integration
+omo [backup|restore]                           oh-my-opencode preferences
+```
+
+### `bin/devtools-clean-branch`
+
+Rebuild a polluted PR branch by cherry-picking selected commits onto a clean base.
+
+```text
+devtools-clean-branch [OPTIONS] TARGET_BRANCH WORK_BRANCH
+  -r REMOTE     Remote name (default: origin)
+  -c COMMITS    Comma/space-separated hashes or HASH1..HASH2 ranges (skips interactive selection)
+```
+
+Companion doc: `docs/CleanBranch.md` in the repo.
+
+### `bin/devtools-llm`
+
+Local LLM (Ollama) setup and management. `install [container|native]` auto-detects platform; also `uninstall`, `start`, `stop`, `status`.
+
+### `bin/devtools-rspec-tester`
+
+RSpec helper with SonarQube integration: `{test|coverage|sonar|full|setup-sonar} [path]`. Configured via environment variables from shell config.
+
+## Notes for agents
+
+- **Never rename these script files** — `devtools-opencode` is referenced by name in `stowme.sh` and `.github/workflows/ci-unit-test.yml`.
+- New scripts follow the same rules as the `dotfiles-*` directory: POSIX sh, idempotent steps, non-interactive escape hatches for CI.
+- MCP server definitions consumed by `devtools-opencode` live in `shared/ai-agents/mcps.json`.

--- a/linux/systems/.local/bin/org.jcchikikomori.devtools/CLAUDE.md
+++ b/linux/systems/.local/bin/org.jcchikikomori.devtools/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/CLAUDE.md
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Add CLAUDE.md into the following directories

- [x] Create `/CLAUDE.md`
- [x] Create `CLAUDE.md` in `linux/opencode` package
- [x] Create `CLAUDE.md` in `linux/flatpak` package
- [x] Create `CLAUDE.md` in `linux/supermodel` package - already exists
- [x] Create `CLAUDE.md` in `linux/lindbergh` package
- [x] Create `CLAUDE.md` in `linux/systems` package
- [x] Create `CLAUDE.md` in `linux/git` package
- [x] Create `CLAUDE.md` in `linux/gpg` package