### PR TITLE
Optimize zsh workflow: push shortcuts + CLI completions (#222)

### DIFF
--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-post-setup
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-post-setup
@@ -205,6 +205,7 @@ main() {
     git clone https://github.com/zdharma-continuum/fast-syntax-highlighting.git $ZSH_CUSTOM_PLUGINS_DIR/fast-syntax-highlighting
     git clone --depth 1 -- https://github.com/marlonrichert/zsh-autocomplete.git $ZSH_CUSTOM_PLUGINS_DIR/zsh-autocomplete
     git clone https://github.com/larkery/zsh-histdb.git $ZSH_CUSTOM_PLUGINS_DIR/zsh-histdb
+    git clone https://github.com/MichaelAquilina/zsh-you-should-use.git $ZSH_CUSTOM_PLUGINS_DIR/zsh-you-should-use
 
     echo 'Setting up ~/.profile.local for user customizations...'
     setup_profile_local
@@ -222,4 +223,3 @@ fi
 
 echo 'Executing post-setup...'
 main
-

--- a/linux/zsh/.zalias
+++ b/linux/zsh/.zalias
@@ -7,3 +7,7 @@ if command -v cz >/dev/null 2>&1; then
   alias gcz="cz commit"
   alias gc="cz commit"  # override oh-my-zsh git plugin's `git commit --verbose`
 fi
+
+# Push current branch (from oh-my-zsh git plugin, see `alias | grep git_current_branch`):
+#   gpsup  - push + set upstream to origin/<current-branch> (first push of a new branch)
+#   ggpush - push already-tracked current branch

--- a/linux/zsh/.zfunctions
+++ b/linux/zsh/.zfunctions
@@ -14,3 +14,18 @@ remlower() {
     done
   done
 }
+
+# Insert current git branch at cursor (bound to a key in .zshrc)
+insert-current-branch() {
+  LBUFFER+="$(git_current_branch 2>/dev/null)"
+  zle redisplay
+}
+zle -N insert-current-branch
+
+# zsh-autosuggestions strategy: after a commit, ghost-suggest a push
+_zsh_autosuggest_strategy_git_next_action() {
+  local last_cmd="$(fc -ln -1 2>/dev/null)"
+  if [[ $last_cmd == (git commit|gc|gcz|cz commit)* ]]; then
+    typeset -g suggestion="gpsup"
+  fi
+}

--- a/linux/zsh/.zfunctions
+++ b/linux/zsh/.zfunctions
@@ -29,3 +29,24 @@ _zsh_autosuggest_strategy_git_next_action() {
     typeset -g suggestion="gpsup"
   fi
 }
+
+# Reminder when the long-form push is typed out instead of gpsup/ggpush.
+# zsh-you-should-use can't catch these: its matcher compares against the
+# alias's raw text, and gpsup/ggpush embed $(git_current_branch) — a
+# command substitution zsh never expands in preexec, so it can never equal
+# a typed line containing the real branch name. This hook evaluates the
+# branch itself instead, so it can actually match.
+_check_push_alias_usage() {
+  local typed="$1"
+  local branch
+  branch="$(git_current_branch 2>/dev/null)"
+  [[ -z $branch ]] && return
+  case "$typed" in
+    "git push --set-upstream origin $branch"|"git push -u origin $branch")
+      print -P "%F{yellow}Tip: %F{magenta}gpsup%f does that in one step.%f" >&2
+      ;;
+    "git push origin $branch"|"git push origin \"$branch\"")
+      print -P "%F{yellow}Tip: %F{magenta}ggpush%f does that in one step.%f" >&2
+      ;;
+  esac
+}

--- a/linux/zsh/.zsh/completions/_claude
+++ b/linux/zsh/.zsh/completions/_claude
@@ -1,0 +1,100 @@
+#compdef claude
+
+# Zsh completion for the `claude` CLI (Claude Code).
+# Hand-maintained snapshot (claude has no built-in completion generator,
+# unlike opencode) — re-sync against `claude --help` / `claude <cmd> --help`
+# if this drifts.
+
+_claude() {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments -C \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '(-v --version)'{-v,--version}'[Output the version number]' \
+    '(-p --print)'{-p,--print}'[Non-interactive output]' \
+    '--agent[Agent for the current session]:agent name' \
+    '--model[Model to use for the session]:model' \
+    '--add-dir[Additional directories to allow tool access to]:directory:_files -/' \
+    '(-c --continue)'{-c,--continue}'[Continue the most recent conversation]' \
+    '(-r --resume)'{-r,--resume}'[Resume a conversation]:session id' \
+    '--permission-mode[Permission mode for the session]:mode' \
+    '1: :->command' \
+    '*:: :->args'
+
+  case "$state" in
+    command)
+      _values 'claude command' \
+        'agents[Manage background agents]' \
+        'auth[Manage authentication]' \
+        'auto-mode[Inspect or reset auto mode classifier configuration]' \
+        'doctor[Check the health of your Claude Code installation]' \
+        'gateway[Run the enterprise auth/telemetry gateway]' \
+        'install[Install Claude Code native build]' \
+        'mcp[Configure and manage MCP servers]' \
+        'plugin[Manage Claude Code plugins]' \
+        'plugins[Manage Claude Code plugins]' \
+        'project[Manage Claude Code project state]' \
+        'setup-token[Set up a long-lived authentication token]' \
+        'ultrareview[Run a cloud-hosted multi-agent code review]' \
+        'update[Check for updates and install if available]' \
+        'upgrade[Check for updates and install if available]'
+      ;;
+    args)
+      case "$line[1]" in
+        mcp)
+          _values 'mcp subcommand' \
+            'add[Add an MCP server to Claude Code]' \
+            'add-from-claude-desktop[Import MCP servers from Claude Desktop]' \
+            'add-json[Add an MCP server with a JSON string]' \
+            'get[Get details about an MCP server]' \
+            'list[List configured MCP servers]' \
+            'login[Authenticate with an MCP server]' \
+            'logout[Clear stored OAuth credentials for an MCP server]' \
+            'remove[Remove an MCP server]' \
+            'reset-project-choices[Reset approved/rejected project-scoped servers]' \
+            'serve[Start the Claude Code MCP server]'
+          ;;
+        plugin|plugins)
+          _values 'plugin subcommand' \
+            'details[Show a plugin'"'"'s component inventory and token cost]' \
+            'disable[Disable an enabled plugin]' \
+            'enable[Enable a disabled plugin]' \
+            'eval[Run eval cases against a plugin]' \
+            'init[Scaffold a new plugin]' \
+            'new[Scaffold a new plugin]' \
+            'install[Install a plugin from available marketplaces]' \
+            'i[Install a plugin from available marketplaces]' \
+            'list[List installed plugins]' \
+            'marketplace[Manage Claude Code marketplaces]' \
+            'prune[Remove auto-installed dependencies no longer needed]' \
+            'autoremove[Remove auto-installed dependencies no longer needed]' \
+            'tag[Create a release git tag for a plugin]' \
+            'uninstall[Uninstall an installed plugin]' \
+            'remove[Uninstall an installed plugin]' \
+            'update[Update a plugin to the latest version]' \
+            'validate[Validate a plugin or marketplace manifest]'
+          ;;
+        auth)
+          _values 'auth subcommand' \
+            'login[Sign in to your Anthropic account]' \
+            'logout[Log out from your Anthropic account]' \
+            'status[Show authentication status]'
+          ;;
+        project)
+          _values 'project subcommand' \
+            'purge[Delete all Claude Code state for a project]'
+          ;;
+        auto-mode)
+          _values 'auto-mode subcommand' \
+            'config[Print the effective auto mode config as JSON]' \
+            'critique[Get AI feedback on your custom auto mode rules]' \
+            'defaults[Print the default auto mode rules as JSON]' \
+            'reset[Reset auto mode configuration to the shipped defaults]'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_claude "$@"

--- a/linux/zsh/.zshrc
+++ b/linux/zsh/.zshrc
@@ -173,6 +173,10 @@ source $HOME/.zfunctions
 # zsh-autosuggestions: try our git-commit->push strategy first, fall back to history
 ZSH_AUTOSUGGEST_STRATEGY=(git_next_action history)
 
+# Remind about gpsup/ggpush when the long-form push is typed out instead
+# (see _check_push_alias_usage in .zfunctions for why zsh-you-should-use can't)
+add-zsh-hook preexec _check_push_alias_usage
+
 ## Options section
 setopt correct                                                  # Auto correct mistakes
 setopt extendedglob                                             # Extended globbing. Allows using regular expressions with *

--- a/linux/zsh/.zshrc
+++ b/linux/zsh/.zshrc
@@ -75,7 +75,7 @@ COMPLETION_WAITING_DOTS="true"
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 # Note: Ensure to execute ~/.dotfiles/git-flow.sh before using other plugins
-plugins=(brew git globalias gradle grails git-flow-completion zsh-autosuggestions fast-syntax-highlighting)
+plugins=(brew git globalias gradle grails git-flow-completion zsh-autosuggestions fast-syntax-highlighting zsh-you-should-use)
 
 
 # User configuration
@@ -170,6 +170,9 @@ auto_load_venv  # Run on shell initialization too
 # Set other functions
 source $HOME/.zfunctions
 
+# zsh-autosuggestions: try our git-commit->push strategy first, fall back to history
+ZSH_AUTOSUGGEST_STRATEGY=(git_next_action history)
+
 ## Options section
 setopt correct                                                  # Auto correct mistakes
 setopt extendedglob                                             # Extended globbing. Allows using regular expressions with *
@@ -204,6 +207,12 @@ zstyle ':completion:*' cache-path ~/.cache/zcache
 
 # automatically load bash completion functions
 autoload -U +X bashcompinit && bashcompinit
+
+# opencode ships its own zsh completion generator
+command -v opencode >/dev/null 2>&1 && eval "$(opencode completion zsh)"
+
+# Insert current git branch at cursor (see insert-current-branch in .zfunctions)
+bindkey '^Xb' insert-current-branch
 
 HISTFILE=~/.zhistory
 HISTSIZE=50000


### PR DESCRIPTION
## Summary
- Surface existing oh-my-zsh `gpsup`/`ggpush` aliases and add a `preexec` hook (`_check_push_alias_usage`) that prints a tip when the long-form push is typed out instead — `zsh-you-should-use` can't catch these because it string-matches against the alias's raw, unexpanded RHS, and `gpsup`/`ggpush` embed `$(git_current_branch)`, a substitution zsh never expands in `preexec`.
- Add `insert-current-branch` ZLE widget bound to `Ctrl-X b` — inserts the current git branch at the cursor.
- Add a `zsh-autosuggestions` custom strategy (`git_next_action`) that ghost-suggests `gpsup` on the next empty prompt after a commit.
- Wire up `opencode completion zsh` (native generator) and hand-write a static `_claude` completion file (claude has no built-in generator) — verified subcommand list against real `claude <cmd> --help` output.
- Add the `zsh-you-should-use` plugin for general alias-discoverability (oh-my-zsh custom plugin, same clone pattern as the other custom plugins in `dotfiles-post-setup`).

Closes #222

## Test plan
- [x] `zsh -n` on `.zshrc`, `.zalias`, `.zfunctions`, `_claude` — no syntax errors
- [x] `docker compose run --rm dotfiles-ci-debian` — zsh package stows cleanly
- [x] Manually verified on a separate VM: `Ctrl-X b` inserts current branch; long-form `git push --set-upstream origin <branch>` prints the `gpsup` tip
- [ ] Manually verify: post-commit `gpsup` ghost-suggestion; `claude`/`opencode` TAB completion