### PR TITLE
docs(github): add Feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: 🧾 Feature
+description: Adding new feature or updating existing components
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees:
+  - jcchikikomori
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! 🙏
+        Please provide as much detail as possible to help us evaluate this.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this feature solve, or what's missing today?
+      placeholder: Describe the gap or pain point...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: What would you like to see added or changed?
+      placeholder: Describe your proposed feature or change...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative approaches or workarounds you've considered.
+      placeholder: Describe alternatives...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, links, or screenshots.
+      placeholder: Any other relevant information...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following before submitting
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate
+          required: true
+        - label: I have read the [README](https://github.com/jcchikikomori/.dotfiles/blob/master/README.MD) and relevant documentation
+          required: true


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/feature_request.yml`, mirroring `bug_report.yml`'s structure
- Auto-assigns `jcchikikomori`, labels `enhancement`, prefixes title `[Feature]: `

Closes #223

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] Confirm template appears in GitHub issue picker with correct name/description
- [ ] Confirm new issue auto-assigns and auto-labels as expected