### PR TITLE
feat(rust): add rust/cargo, exiftool, and xdvdfs-cli setup

### DIFF
--- a/arch/setup.sh
+++ b/arch/setup.sh
@@ -25,6 +25,16 @@ pacman_install "-S --noconfirm --noprogressbar" xclip
 # Install mirror management tools
 pacman_install "-S --noconfirm --noprogressbar" rankmirrors reflector
 
+# Rust toolchain (bundles cargo) + exiftool
+pacman_install "-S --noconfirm --noprogressbar" rust perl-image-exiftool
+
+# Install xdvdfs-cli via cargo
+if command -v cargo >/dev/null 2>&1; then
+  cargo install xdvdfs-cli || echo "Warning: xdvdfs-cli install via cargo failed/skipped."
+else
+  echo "Warning: cargo not found, skipping xdvdfs-cli install."
+fi
+
 # Post-Setup
 if command -v zenity >/dev/null 2>&1; then
   zenity --info --title="Setup Completed" --text="Please install dependencies into your home directory (Execute: dotfiles-post-setup)."

--- a/darwin/setup.sh
+++ b/darwin/setup.sh
@@ -28,7 +28,14 @@ export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_ENV_HINTS=1
 
 brew update
-brew install stow git zsh tmux wget coreutils rclone
+brew install stow git zsh tmux wget coreutils rclone rust exiftool
+
+# Install xdvdfs-cli via cargo
+if command -v cargo >/dev/null 2>&1; then
+  cargo install xdvdfs-cli || echo "Warning: xdvdfs-cli install via cargo failed/skipped."
+else
+  echo "Warning: cargo not found, skipping xdvdfs-cli install."
+fi
 
 if ! xcode-select -p >/dev/null 2>&1; then
   if [ -n "$CI" ]; then

--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -34,6 +34,16 @@ $SUDO apt install -y libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3
 # Installing rclone
 $SUDO apt install -y rclone
 
+# Rust toolchain + cargo + exiftool
+$SUDO apt install -y rustc cargo libimage-exiftool-perl
+
+# Install xdvdfs-cli via cargo
+if command -v cargo >/dev/null 2>&1; then
+  cargo install xdvdfs-cli || echo "Warning: xdvdfs-cli install via cargo failed/skipped."
+else
+  echo "Warning: cargo not found, skipping xdvdfs-cli install."
+fi
+
 # Setting default locale (skip loadkeys on WSL as it doesn't support console keymaps)
 if [ -f /proc/version ] && grep -qi microsoft /proc/version; then
   echo "WSL detected: Skipping loadkeys (not supported in WSL)."

--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -34,8 +34,13 @@ $SUDO apt install -y libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3
 # Installing rclone
 $SUDO apt install -y rclone
 
-# Rust toolchain + cargo + exiftool
-$SUDO apt install -y rustc cargo libimage-exiftool-perl
+# Rust toolchain via rustup (apt's rustc/cargo on Debian is too old to build
+# current crates - xdvdfs-cli requires Rust edition 2024, rustc >= 1.85) + exiftool
+$SUDO apt install -y libimage-exiftool-perl
+if ! command -v cargo >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
 
 # Install xdvdfs-cli via cargo
 if command -v cargo >/dev/null 2>&1; then

--- a/linux/bash/.bashrc.d/03-dev
+++ b/linux/bash/.bashrc.d/03-dev
@@ -14,6 +14,11 @@ if [ -d "$RBENV_ROOT" ]; then
     eval "$(rbenv init - --no-rehash bash)"
 fi
 
+# Rust/Cargo
+if [ -d "$HOME/.cargo/bin" ]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
 # Linuxbrew/Homebrew
 if [ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
     eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -69,4 +74,3 @@ esac
 
 # Run on shell initialization too
 auto_load_venv
-

--- a/linux/systems/.profile
+++ b/linux/systems/.profile
@@ -142,6 +142,11 @@ if [ -d "$RBENV_ROOT" ]; then
     eval "$(rbenv init -)"
 fi
 
+# Rust/Cargo
+if [ -d "$HOME/.cargo/bin" ]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
 if [ -d "$NVM_DIR" ]; then
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
     [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/rhel/setup.sh
+++ b/rhel/setup.sh
@@ -11,6 +11,16 @@ sudo dnf install -y zenity
 # Installing rclone
 sudo dnf install -y rclone
 
+# Rust toolchain + cargo + exiftool
+sudo dnf install -y rust cargo perl-Image-ExifTool
+
+# Install xdvdfs-cli via cargo
+if command -v cargo >/dev/null 2>&1; then
+  cargo install xdvdfs-cli || echo "Warning: xdvdfs-cli install via cargo failed/skipped."
+else
+  echo "Warning: cargo not found, skipping xdvdfs-cli install."
+fi
+
 # Python
 sudo dnf install -y python2 python3 libssh-devel libgcrypt libgcrypt-devel tk-devel tc-devel
 sudo dnf install -y bzip2-devel ncurses-devel libffi-devel readline-devel openssl-devel xz-devel libuuid-devel gdbm-libs libnsl2

--- a/steamos/setup.sh
+++ b/steamos/setup.sh
@@ -24,6 +24,16 @@ pacman_install "-S --needed --noconfirm --noprogressbar" \
   nano htop iftop mtr dkms lz4 bash-completion base-devel pacman-contrib \
   git zsh unzip python3 zip vi fakeroot openssh stow sqlite tmux wget entr less
 
+# Rust toolchain (bundles cargo) + exiftool
+pacman_install "-S --needed --noconfirm --noprogressbar" rust perl-image-exiftool
+
+# Install xdvdfs-cli via cargo
+if command -v cargo >/dev/null 2>&1; then
+  cargo install xdvdfs-cli || echo "Warning: xdvdfs-cli install via cargo failed/skipped."
+else
+  echo "Warning: cargo not found, skipping xdvdfs-cli install."
+fi
+
 # Install AUR helper, then mandatory + optional edge packages
 "$DOTFILES_BIN/dotfiles-arch" install-yay
 "$DOTFILES_BIN/dotfiles-arch" install-packages

--- a/termux/setup.sh
+++ b/termux/setup.sh
@@ -13,6 +13,14 @@ pkg update
 pkg install -y apt ca-certificates curl
 pkg install -y stow vim nano htop git zsh build-essential which
 pkg install -y python zip openssh ncdu wget tmux unzip rclone
+pkg install -y rust exiftool
+
+# Install xdvdfs-cli via cargo
+if command -v cargo >/dev/null 2>&1; then
+  cargo install xdvdfs-cli || echo "Warning: xdvdfs-cli install via cargo failed/skipped."
+else
+  echo "Warning: cargo not found, skipping xdvdfs-cli install."
+fi
 
 # Setting default locale
 # Termux does not use loadkeys or localectl, locale settings are managed differently

--- a/ubuntu/setup.sh
+++ b/ubuntu/setup.sh
@@ -20,8 +20,13 @@ sudo apt-get install -y libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqli
 # Installing rclone
 sudo apt-get install -y rclone
 
-# Rust toolchain + cargo + exiftool
-sudo apt-get install -y rustc cargo libimage-exiftool-perl
+# Rust toolchain via rustup (apt's rustc/cargo on Ubuntu is too old to build
+# current crates - xdvdfs-cli requires Rust edition 2024, rustc >= 1.85) + exiftool
+sudo apt-get install -y libimage-exiftool-perl
+if ! command -v cargo >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
 
 # Install xdvdfs-cli via cargo
 if command -v cargo >/dev/null 2>&1; then

--- a/ubuntu/setup.sh
+++ b/ubuntu/setup.sh
@@ -20,6 +20,16 @@ sudo apt-get install -y libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqli
 # Installing rclone
 sudo apt-get install -y rclone
 
+# Rust toolchain + cargo + exiftool
+sudo apt-get install -y rustc cargo libimage-exiftool-perl
+
+# Install xdvdfs-cli via cargo
+if command -v cargo >/dev/null 2>&1; then
+  cargo install xdvdfs-cli || echo "Warning: xdvdfs-cli install via cargo failed/skipped."
+else
+  echo "Warning: cargo not found, skipping xdvdfs-cli install."
+fi
+
 # Setting default locale (skip loadkeys on WSL as it doesn't support console keymaps)
 if [ -f /proc/version ] && grep -qi microsoft /proc/version; then
   echo "WSL detected: Skipping loadkeys (not supported in WSL)."


### PR DESCRIPTION
## Summary

- Install `rust`/`cargo` + `exiftool` as native system packages on Arch/SteamOS (pacman `extra`), Fedora/RHEL (dnf), macOS (brew), Termux (pkg).
- Debian/Ubuntu install Rust via the official rustup bootstrap script instead of apt's `rustc`/`cargo` — confirmed Debian bookworm ships 1.65 and Ubuntu noble ships 1.75, both below the rustc 1.85 required by `xdvdfs-cli`'s current dependency tree (Rust edition 2024).
- `cargo install xdvdfs-cli` runs after rust/cargo is available, on every distro.
- Add `$HOME/.cargo/bin` to `PATH` in `linux/systems/.profile` and `linux/bash/.bashrc.d/03-dev`.

Closes #219

## Test plan

- [x] `sh -n` syntax check on all 7 modified `setup.sh` files
- [x] `pre-commit run` on changed files
- [x] Verified `cargo install xdvdfs-cli` compiles clean in isolated containers: Debian bookworm-slim (via rustup), Ubuntu noble (via rustup), Fedora latest (native dnf rust/cargo 1.97.1), Arch latest (native pacman rust 1.97.1)
- [x] CI (`ci-unit-test.yml` ubuntu/arch/fedora/debian jobs) — pending this PR
- [ ] Termux/SteamOS/darwin paths not covered by CI; package names verified against upstream registries but installs unverified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)