### PR TITLE
refactor(shell): fix uv autoload and shell startup PATH ordering

### DIFF
--- a/.profile.local.example
+++ b/.profile.local.example
@@ -15,8 +15,7 @@
 # export MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA
 
 # Source Python environments (uncomment the one you use)
-# For uv (recommended for Steam Deck):
-# [ -f ~/.config/dotfiles-python/env-uv ] && . ~/.config/dotfiles-python/env-uv
+# uv is auto-loaded already via ~/.profile / ~/.bashrc.d/03-dev - no entry needed here.
 
 # For Miniconda:
 # [ -f ~/.config/dotfiles-python/env-conda ] && . ~/.config/dotfiles-python/env-conda

--- a/linux/bash/.bashrc.d/03-dev
+++ b/linux/bash/.bashrc.d/03-dev
@@ -19,6 +19,11 @@ if [ -d "$HOME/.cargo/bin" ]; then
     export PATH="$HOME/.cargo/bin:$PATH"
 fi
 
+# uv (Python package/env manager) - see dotfiles-python
+if [ -f "$HOME/.config/dotfiles-python/env-uv" ]; then
+    . "$HOME/.config/dotfiles-python/env-uv"
+fi
+
 # Linuxbrew/Homebrew
 if [ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
     eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-python
+++ b/linux/systems/.local/bin/org.jcchikikomori.dotfiles/bin/dotfiles-python
@@ -133,24 +133,24 @@ add_to_profile_local() {
     local init_file="$1"
     local manager_name="$2"
     local profile_local="$HOME/.profile.local"
-    
+
     # If profile.local doesn't exist, skip
     if [ ! -f "$profile_local" ]; then
         log_info "Note: $profile_local not found, skipping auto-add for $manager_name"
         return 0
     fi
-    
+
     # Check if already present
     if grep -q "$(basename "$init_file")" "$profile_local" 2>/dev/null; then
         log_info "$manager_name already configured in $profile_local"
         return 0
     fi
-    
+
     if [ "$DRY_RUN" = "true" ]; then
         log_info "[DRY-RUN] Would add $manager_name to $profile_local"
         return 0
     fi
-    
+
     # Append to profile.local
     printf '\n# %s Python environment\n' "$manager_name" >> "$profile_local"
     printf '[ -f %s ] && . %s\n' "$init_file" "$init_file" >> "$profile_local"
@@ -161,24 +161,24 @@ add_to_profile_local() {
 add_venv_activation_to_profile_local() {
     local profile_local="$HOME/.profile.local"
     local venv_activate="$HOME/.venv/global/bin/activate"
-    
+
     # If profile.local doesn't exist, skip
     if [ ! -f "$profile_local" ]; then
         log_info "Note: $profile_local not found, skipping venv auto-activation"
         return 0
     fi
-    
+
     # Check if already present
     if grep -q "\.venv/global/bin/activate" "$profile_local" 2>/dev/null; then
         log_info "Global venv already configured in $profile_local"
         return 0
     fi
-    
+
     if [ "$DRY_RUN" = "true" ]; then
         log_info "[DRY-RUN] Would add global venv activation to $profile_local"
         return 0
     fi
-    
+
     # Append venv activation
     printf '\n# Global Python venv (auto-created by dotfiles-python)\n' >> "$profile_local"
     printf 'if [ -d "%s" ]; then\n' "$HOME/.venv" >> "$profile_local"
@@ -191,18 +191,18 @@ add_venv_activation_to_profile_local() {
 remove_from_profile_local() {
     local marker="$1"
     local profile_local="$HOME/.profile.local"
-    
+
     if [ ! -f "$profile_local" ]; then
         return 0
     fi
-    
+
     if [ "$DRY_RUN" = "true" ]; then
         if grep -q "$marker" "$profile_local" 2>/dev/null; then
             log_info "[DRY-RUN] Would remove '$marker' from $profile_local"
         fi
         return 0
     fi
-    
+
     # Create temp file and remove lines containing the marker
     local temp_file
     temp_file="$(mktemp)"
@@ -723,10 +723,7 @@ UV_EOF
     echo "  To activate immediately:"
     echo "  source $HOME/.venv/global/bin/activate"
     echo ""
-    log_info "IMPORTANT: Add this to your shell config (~/.bashrc, ~/.zshrc, etc.):"
-    echo ""
-    echo "  # Load uv from dotfiles-python"
-    echo "  [ -f ~/.config/dotfiles-python/env-uv ] && . ~/.config/dotfiles-python/env-uv"
+    log_info "$DOTFILES_PYTHON_CONFIG_DIR/env-uv will be loaded automatically on your next shell restart."
     echo ""
 }
 

--- a/linux/systems/.profile
+++ b/linux/systems/.profile
@@ -147,6 +147,11 @@ if [ -d "$HOME/.cargo/bin" ]; then
     export PATH="$HOME/.cargo/bin:$PATH"
 fi
 
+# uv (Python package/env manager) - see dotfiles-python
+if [ -f "$HOME/.config/dotfiles-python/env-uv" ]; then
+    . "$HOME/.config/dotfiles-python/env-uv"
+fi
+
 if [ -d "$NVM_DIR" ]; then
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
     [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/linux/zsh/.zshrc
+++ b/linux/zsh/.zshrc
@@ -1,3 +1,8 @@
+## profile
+# Load first so PATH/dev-tool setup (pyenv, rbenv, cargo, nvm, sdkman, uv, ...)
+# exists before oh-my-zsh, compinit, and antigen start doing command lookups.
+source $HOME/.profile
+
 # NVM via Homebrew — load early before any Homebrew node
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 if command -v brew >/dev/null 2>&1; then
@@ -224,9 +229,6 @@ SAVEHIST=10000
 
 ## emacs
 source $HOME/.emacsbinding
-
-## profile
-source $HOME/.profile
 
 ## antigen
 source $HOME/.antigenrc


### PR DESCRIPTION
## Summary
- Closes #228 — shell intermittently failed to find binaries after uv integration
- `.zshrc` now sources `.profile` first, before oh-my-zsh/compinit/antigen, so PATH/dev-tool setup exists before any plugin does command lookups
- uv's `env-uv` is now auto-sourced from `.profile` / `03-dev`, same eager pattern already used for pyenv/rbenv/nvm/sdkman, instead of requiring a manual `~/.profile.local` edit
- Dropped the now-obsolete manual uv line from `.profile.local.example` and the "add this to your shell config" instructions from `dotfiles-python`'s uv installer

## Test plan
- [x] `sh -n` / `zsh -n` syntax check on all changed shell files
- [x] `pre-commit run --all-files` clean
- [x] `docker compose run --rm dotfiles-ci-debian` smoke test passed
- [x] Open a fresh interactive terminal (zsh + bash) and confirm: welcome banner/tmux auto-attach/oh-my-zsh/antigen/compinit/starship still work, `uv`/`uvx`/`python` resolve immediately, `pyenv`/`rbenv`/`nvm`/`sdkman` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)