### PR TITLE
fix(stow): purge stale vscode extensions.json from package source

### DIFF
--- a/stowme.sh
+++ b/stowme.sh
@@ -112,6 +112,31 @@ check_submodules() {
   return 0
 }
 
+# Guard: purge a stale vscode extensions.json leftover from the package source tree.
+# GitHub #229: linux/vscode/.vscode-server/extensions/extensions.json used to be
+# tracked in git until PR #211 removed it (dotfiles-cleanup now restores it as a
+# real, non-stowed file on the $HOME side, since VS Code Server rewrites it
+# constantly and it's machine-specific). Clones that had a locally-modified copy
+# of the file at the time PR #211 landed keep a stray, gitignored copy behind in
+# the package source tree. That stray file collides with the real file
+# dotfiles-cleanup restores at $HOME/.vscode-server/extensions/extensions.json and
+# makes `stow` abort the entire run with:
+#   "existing target is neither a link nor a directory: .vscode-server/extensions/extensions.json"
+cleanup_stray_vscode_extensions() {
+  stray_extensions_dir="$DOTFILES_PATH/linux/vscode/.vscode-server/extensions"
+
+  if [ ! -e "$stray_extensions_dir" ]; then
+    return 0
+  fi
+
+  backup_dir="$HOME/.backups"
+  mkdir -p "$backup_dir"
+  timestamp=$(date +%Y%m%d-%H%M%S)
+  cp -a "$stray_extensions_dir" "$backup_dir/vscode-extensions-stray.$timestamp"
+  rm -rf "$stray_extensions_dir"
+  log_positive "Removed stray $stray_extensions_dir (backed up to $backup_dir/vscode-extensions-stray.$timestamp)"
+}
+
 resolve_dotstow() {
   if command -v dotstow >/dev/null 2>&1; then
     command -v dotstow
@@ -179,6 +204,9 @@ if ! check_submodules; then
   log_error "Run: git submodule update --init --recursive"
   exit 1
 fi
+
+# Guard: remove stale vscode extensions.json leftover from the package source (#229)
+cleanup_stray_vscode_extensions
 
 # Handle ~/.profile conflict before stowing
 # If ~/.profile exists as a real file (not symlink), back it up


### PR DESCRIPTION
## Summary

- Fixes #229: `./stowme.sh` aborts on the `vscode` package with `WARNING! stowing vscode would cause conflicts: * existing target is neither a link nor a directory: .vscode-server/extensions/extensions.json`.
- Root cause: `linux/vscode/.vscode-server/extensions/extensions.json` was tracked in git until PR #211 removed it from tracking (in favor of `dotfiles-cleanup` restoring it as a real, non-stowed file at `$HOME`, since VS Code Server rewrites it constantly and it's machine-local data). Dotfiles clones that had a locally-modified copy of the file at the time PR #211 landed were left with a stray, now-gitignored leftover of that file still physically present inside the **package source tree** (git does not delete a locally-modified file when upstream deletes it). That stray source-side file collides with the real target-side file `dotfiles-cleanup` restores at `$HOME/.vscode-server/extensions/extensions.json`, making `stow` abort the entire run.
- Fix: add a guard (`cleanup_stray_vscode_extensions`) to the canonical `stowme.sh` entrypoint, run before `dotstow stow`, that detects and backs up (to `$HOME/.backups`) then removes any stray `linux/vscode/.vscode-server/extensions/` leftover from the package source before stowing. This is additive/idempotent and only touches a path that is explicitly `.gitignore`d and, by design, never meant to be part of the stowed package tree.

## Note on issue auto-close

This PR targets `develop` (git-flow base branch), not the repo's actual default branch (`master`). GitHub's `Closes #229` auto-close will **not** fire when this merges. Issue #229 will need to be closed manually once this lands.

## Test plan

- [x] `sh -n` / `dash -n` syntax check on `stowme.sh`
- [x] Isolated unit test of the new guard function (removes + backs up stray file; no-op/idempotent when absent)
- [x] Full Docker smoke test: `docker compose run --rm dotfiles-ci-debian` passes
- [x] Targeted regression test in the Docker toolchain: seeded the exact real-world bug scenario (stray file in package source + real file at target) — confirmed the fix removes the stray file, preserves the real target-side file untouched, and `stow` completes without the vscode conflict
- [x] Negative control: reverted only `stowme.sh` to the pre-fix `develop` version with the same seeded scenario — reproduced the reported error verbatim, confirming the fix addresses the actual root cause
- [ ] Manual verification on a real WSL2/Ubuntu machine with an actual stale `extensions.json` leftover from an old clone (the original reporter's environment) — needs a human with that exact setup to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)